### PR TITLE
feat: SEO & trust foundation (metadata, sitemap, FAQ, legal pages)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,8 +3,47 @@ import { GoogleTagManager } from '@next/third-parties/google';
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "txtconv - 簡繁轉換工具",
-  description: "將簡體中文文字檔案轉換為繁體中文",
+  metadataBase: new URL("https://txtconv.arpuli.com"),
+  title: {
+    default: "txtconv - 簡轉繁線上工具｜字幕、小說 TXT 簡體轉繁體",
+    template: "%s | txtconv 簡轉繁工具",
+  },
+  description:
+    "免費線上簡轉繁工具：上傳 .txt 小說、.srt 字幕（剪映/CapCut）、.csv、.xml 檔案，一鍵將簡體中文轉換成台灣繁體中文。自動偵測 GBK/Big5 編碼、支援批次轉換與自訂字典，轉換在瀏覽器完成、速度快。",
+  keywords: [
+    "簡轉繁",
+    "簡體轉繁體",
+    "簡繁轉換",
+    "txt 簡轉繁",
+    "srt 字幕簡轉繁",
+    "剪映字幕轉繁體",
+    "CapCut 字幕簡轉繁",
+    "小說簡轉繁",
+    "簡體亂碼轉換",
+    "ConvertZ 線上版",
+  ],
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    url: "https://txtconv.arpuli.com",
+    siteName: "txtconv",
+    title: "txtconv - 簡轉繁線上工具｜字幕、小說 TXT 簡體轉繁體",
+    description:
+      "免費線上將 .txt 小說、.srt 字幕、.csv、.xml 從簡體轉成繁體中文。自動偵測編碼、批次轉換、自訂字典。",
+    locale: "zh_TW",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "txtconv - 簡轉繁線上工具",
+    description:
+      "免費線上將 .txt 小說、.srt 字幕、.csv、.xml 從簡體轉成繁體中文。自動偵測編碼、批次轉換、自訂字典。",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,52 @@
+import { ImageResponse } from 'next/og';
+
+/**
+ * Open Graph image generated at the edge with next/og. Used as the link
+ * preview card when the site is shared on social media and chat apps;
+ * no static image asset is needed.
+ */
+export const runtime = 'edge';
+export const alt = 'txtconv - 簡轉繁線上工具';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#0f172a',
+          color: '#ffffff',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div style={{ fontSize: 96, fontWeight: 700, display: 'flex' }}>
+          简 → 繁
+        </div>
+        <div style={{ fontSize: 56, fontWeight: 700, marginTop: 40, display: 'flex' }}>
+          txtconv 簡轉繁線上工具
+        </div>
+        <div style={{ fontSize: 32, color: '#94a3b8', marginTop: 24, display: 'flex' }}>
+          字幕 .srt ・ 小說 .txt ・ .csv ・ .xml 一鍵簡體轉繁體
+        </div>
+        <div
+          style={{
+            marginTop: 48,
+            fontSize: 28,
+            color: '#00D1B2',
+            display: 'flex',
+          }}
+        >
+          txtconv.arpuli.com
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import CustomDictEditor from '@/components/CustomDictEditor';
+import FaqSection from '@/components/FaqSection';
 import FileUpload from '@/components/FileUpload';
 import Footer from '@/components/Footer';
 import Header from '@/components/Header';
@@ -45,6 +46,29 @@ export default async function Home() {
         <PricingSection
           gumroadUrl={process.env.NEXT_PUBLIC_GUMROAD_URL || 'https://gumroad.com'}
           licenseType={profile?.license_type ?? 'free'}
+        />
+
+        <FaqSection />
+
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'WebApplication',
+              name: 'txtconv',
+              url: 'https://txtconv.arpuli.com',
+              applicationCategory: 'UtilitiesApplication',
+              operatingSystem: 'Web',
+              description:
+                '線上簡轉繁工具：將 .txt 小說、.srt 字幕、.csv、.xml 檔案從簡體中文轉換成台灣繁體中文，自動偵測編碼並支援自訂字典。',
+              inLanguage: 'zh-TW',
+              offers: [
+                { '@type': 'Offer', name: 'Free', price: '0', priceCurrency: 'USD' },
+                { '@type': 'Offer', name: 'Lifetime', price: '30', priceCurrency: 'USD' },
+              ],
+            }),
+          }}
         />
       </main>
 

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,93 @@
+import type { Metadata } from 'next';
+import Footer from '@/components/Footer';
+import Header from '@/components/Header';
+import { getAuthUser, getProfile } from '@/lib/actions/auth';
+
+/**
+ * Privacy policy page. Discloses what data the service collects
+ * (account email, uploaded file archiving, analytics) and how it is
+ * used; linked from the site footer and required for user trust and
+ * payment-provider compliance.
+ */
+
+export const metadata: Metadata = {
+  title: '隱私權政策',
+  description:
+    'txtconv 隱私權政策：說明帳號資料、檔案處理、網站分析資料的收集與使用方式。',
+  alternates: { canonical: '/privacy' },
+};
+
+export default async function PrivacyPage() {
+  const user = await getAuthUser();
+  const profile = user ? await getProfile(user.id) : null;
+
+  return (
+    <>
+      <Header user={user} profile={profile} />
+
+      <main className="flex-1 max-w-3xl mx-auto w-full px-6 py-12 space-y-8 text-gray-700">
+        <h1 className="text-3xl font-bold text-gray-800">隱私權政策</h1>
+        <p className="text-sm text-gray-500">最後更新：2026 年 7 月 3 日</p>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-bold text-gray-800">我們收集哪些資料</h2>
+          <ul className="list-disc pl-6 space-y-2 text-sm leading-relaxed">
+            <li>
+              <strong>帳號資料：</strong>當你註冊或登入時，我們透過
+              Supabase 儲存你的電子郵件地址與登入紀錄，用於識別你的方案權益（免費版／Pro）。
+            </li>
+            <li>
+              <strong>上傳的檔案：</strong>簡繁轉換在你的瀏覽器內執行。為了服務品質改善與問題排查，
+              你上傳的原始檔案可能會被存檔到我們的檔案儲存空間（Vercel
+              Blob）。若你不希望檔案被保留，請來信告知，我們會協助刪除。
+            </li>
+            <li>
+              <strong>自訂字典：</strong>你建立的自訂字典內容會儲存在雲端，供你跨裝置使用。
+            </li>
+            <li>
+              <strong>網站分析：</strong>我們使用 Google Tag Manager 與 Google
+              Analytics 收集匿名的使用統計（如頁面瀏覽、轉換次數、檔案格式類型），用於改善產品。
+            </li>
+            <li>
+              <strong>付款資料：</strong>Pro 方案付款由 Gumroad
+              處理，我們不會接觸或儲存你的信用卡資料；我們僅會收到訂單編號、購買者
+              email 與付款狀態，用於開通你的方案。
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-bold text-gray-800">我們如何使用資料</h2>
+          <p className="text-sm leading-relaxed">
+            資料僅用於：提供與改善轉換服務、開通付費方案權益、統計產品使用情況、以及回覆你的支援請求。
+            我們不會出售或出租你的個人資料給第三方。
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-bold text-gray-800">資料刪除</h2>
+          <p className="text-sm leading-relaxed">
+            你可以隨時來信{' '}
+            <a href="mailto:hi.upchen@gmail.com" className="text-primary hover:underline">
+              hi.upchen@gmail.com
+            </a>{' '}
+            要求刪除你的帳號、自訂字典或已存檔的檔案，我們會在 30 天內處理完成。
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-bold text-gray-800">聯絡方式</h2>
+          <p className="text-sm leading-relaxed">
+            對本政策有任何疑問，歡迎來信{' '}
+            <a href="mailto:hi.upchen@gmail.com" className="text-primary hover:underline">
+              hi.upchen@gmail.com
+            </a>
+            。
+          </p>
+        </section>
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from 'next';
+
+/**
+ * Robots.txt metadata route. Allows all crawlers on public pages while
+ * keeping API and auth endpoints out of search indexes, and points
+ * crawlers to the sitemap.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/', '/auth/'],
+    },
+    sitemap: 'https://txtconv.arpuli.com/sitemap.xml',
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from 'next';
+
+/**
+ * Sitemap metadata route. Lists all indexable public pages so search
+ * engines discover them without crawling; update when adding new
+ * public routes (e.g. landing pages or guides).
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = 'https://txtconv.arpuli.com';
+
+  return [
+    {
+      url: `${base}/`,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${base}/privacy`,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    },
+    {
+      url: `${base}/terms`,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    },
+  ];
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from 'next';
+import Footer from '@/components/Footer';
+import Header from '@/components/Header';
+import { getAuthUser, getProfile } from '@/lib/actions/auth';
+
+/**
+ * Terms of service page. States usage terms, plan entitlements, refund
+ * channel (Gumroad), and liability limits; linked from the site footer.
+ */
+
+export const metadata: Metadata = {
+  title: '服務條款',
+  description: 'txtconv 服務條款：使用規範、方案權益、退款方式與免責聲明。',
+  alternates: { canonical: '/terms' },
+};
+
+export default async function TermsPage() {
+  const user = await getAuthUser();
+  const profile = user ? await getProfile(user.id) : null;
+
+  return (
+    <>
+      <Header user={user} profile={profile} />
+
+      <main className="flex-1 max-w-3xl mx-auto w-full px-6 py-12 space-y-8 text-gray-700">
+        <h1 className="text-3xl font-bold text-gray-800">服務條款</h1>
+        <p className="text-sm text-gray-500">最後更新：2026 年 7 月 3 日</p>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-bold text-gray-800">服務內容</h2>
+          <p className="text-sm leading-relaxed">
+            txtconv 提供文字檔案的簡體中文轉繁體中文服務，支援 .txt、.srt、.csv、.xml
+            格式。免費版可使用基本轉換功能（單檔 5MB、自訂字典 5 組）；Pro
+            終身授權提供單檔 100MB 與最多 10,000 組自訂字典對照。
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-bold text-gray-800">使用規範</h2>
+          <ul className="list-disc pl-6 space-y-2 text-sm leading-relaxed">
+            <li>請勿上傳含有惡意程式、違法內容或侵害他人權利的檔案。</li>
+            <li>請確認你擁有所上傳檔案的使用權利；轉換結果的著作權歸屬依原始檔案而定。</li>
+            <li>請勿以自動化程式大量存取本服務或干擾服務運作。</li>
+          </ul>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-bold text-gray-800">付款與退款</h2>
+          <p className="text-sm leading-relaxed">
+            Pro 方案透過 Gumroad 付款。如需退款，請於購買後 14 天內來信{' '}
+            <a href="mailto:hi.upchen@gmail.com" className="text-primary hover:underline">
+              hi.upchen@gmail.com
+            </a>{' '}
+            或透過 Gumroad 申請。
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-bold text-gray-800">免責聲明</h2>
+          <p className="text-sm leading-relaxed">
+            本服務以「現狀」提供。簡繁轉換基於 OpenCC
+            詞庫，無法保證所有詞彙在你的情境下都轉換正確，重要文件請於轉換後自行校對。
+            對於因使用本服務造成的任何損失，我們的責任以你實際支付的費用為上限。
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-bold text-gray-800">條款修改</h2>
+          <p className="text-sm leading-relaxed">
+            我們可能不定期修改本條款，重大變更會在網站上公告。繼續使用本服務即表示你同意修改後的條款。
+          </p>
+        </section>
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/components/FaqSection.tsx
+++ b/components/FaqSection.tsx
@@ -1,0 +1,100 @@
+/**
+ * FAQ and feature-explanation section rendered on the homepage. Server
+ * component (static HTML) that doubles as the site's main indexable
+ * content for search: answers target the long-tail queries users type
+ * (字幕簡轉繁、小說 txt 轉繁體、亂碼、編碼偵測、自訂字典), and the same
+ * Q&A pairs are emitted as FAQPage JSON-LD structured data.
+ */
+
+interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+const FAQ_ITEMS: FaqItem[] = [
+  {
+    question: '如何把剪映（CapCut）匯出的字幕從簡體轉成繁體？',
+    answer:
+      '剪映匯出的 .srt 字幕檔常是簡體中文。把 .srt 檔直接拖曳到 txtconv 上傳區，工具會自動轉換成台灣慣用的繁體中文（例如「软件→軟體」「视频→影片」），轉換完成後點擊下載即可，字幕的時間軸完全不會被更動。',
+  },
+  {
+    question: '簡體 txt 小說打開是亂碼，可以修復嗎？',
+    answer:
+      '可以。亂碼通常是編碼判斷錯誤造成的：簡體檔案多用 GBK/GB18030 編碼，用 Big5 或 UTF-8 開啟就會變亂碼。txtconv 會自動偵測 UTF-8、GBK、GB2312、GB18030、Big5 等常見中文編碼，正確解碼後再轉成繁體，輸出一律是 UTF-8，任何裝置都能正常開啟。',
+  },
+  {
+    question: '轉換是用什麼標準？會把「软件」轉成「軟體」還是「軟件」？',
+    answer:
+      'txtconv 使用 OpenCC 的「簡體到台灣正體（含常用詞彙轉換）」模式，不只逐字轉換，也會把中國大陸用語轉成台灣慣用詞，例如「软件→軟體」「网络→網路」「信息→資訊」。如果有特殊術語想固定譯法，登入後可以在自訂字典加入自己的對照。',
+  },
+  {
+    question: '檔案會被上傳到伺服器嗎？轉換速度快嗎？',
+    answer:
+      '轉換本身完全在你的瀏覽器裡執行，不需等待伺服器排隊，即使幾 MB 的小說檔也能在數秒內完成；批次拖入多個檔案會依序自動轉換。',
+  },
+  {
+    question: '支援哪些檔案格式與大小？',
+    answer:
+      '支援 .txt 純文字（小說、文件）、.srt 影片字幕、.csv 資料表、.xml 資料檔。免費版單檔上限 5MB；升級 Pro（終身授權 US$30）後單檔上限 100MB，並可使用最多 10,000 組自訂字典對照。',
+  },
+  {
+    question: '自訂字典是什麼？什麼情況會用到？',
+    answer:
+      '自訂字典讓你指定「某個簡體詞一律轉成某個繁體詞」，優先於預設轉換規則。常見用途：小說人名、地名、專有名詞（避免被逐字轉錯）、公司內部術語、字幕翻譯風格統一。格式很簡單：每行一組「簡體詞,繁體詞」，也支援匯入與匯出。',
+  },
+  {
+    question: '和 ConvertZ / ConvertZZ 這類軟體有什麼不同？',
+    answer:
+      'ConvertZ 系列是 Windows 桌面軟體，需要下載安裝，在 Mac 上無法使用。txtconv 是網頁工具，打開瀏覽器就能用，Windows、Mac、平板都支援，且內建台灣用語詞彙轉換與自訂字典，不用另外設定。',
+  },
+];
+
+/**
+ * Renders the FAQ accordion-style list plus FAQPage JSON-LD.
+ */
+export default function FaqSection() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: FAQ_ITEMS.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
+    })),
+  };
+
+  return (
+    <section className="py-8">
+      <h2 className="text-3xl font-bold text-center text-gray-800 mb-12">
+        常見問題
+      </h2>
+
+      <div className="space-y-4 max-w-3xl mx-auto">
+        {FAQ_ITEMS.map((item) => (
+          <details
+            key={item.question}
+            className="group bg-white rounded-2xl shadow-sm border border-gray-100 px-6 py-4"
+          >
+            <summary className="cursor-pointer list-none flex items-center justify-between gap-4 font-medium text-gray-800">
+              <h3 className="text-base font-medium">{item.question}</h3>
+              <span className="material-symbols-outlined text-gray-400 transition-transform group-open:rotate-180">
+                expand_more
+              </span>
+            </summary>
+            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+              {item.answer}
+            </p>
+          </details>
+        ))}
+      </div>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </section>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -10,6 +10,14 @@ export default function Footer() {
             © 出走工程師 Up
           </span>
 
+          {/* Legal pages */}
+          <a href="/privacy" className="hover:text-gray-600 transition-colors">
+            隱私權政策
+          </a>
+          <a href="/terms" className="hover:text-gray-600 transition-colors">
+            服務條款
+          </a>
+
           {/* Donate */}
           <a
             href="https://upchen.gumroad.com/l/txtconv?utm_source=txtconv&utm_medium=website&utm_content=footer"


### PR DESCRIPTION
## Why
Site audit (2026-07-03) found txtconv invisible to search beyond one thin page: 2-line metadata, no robots.txt (404), no sitemap (404), no OG tags, no indexable content, no privacy/terms. Meanwhile sales stalled (last sale 2026-05-03) and organic traffic is the main lever.

## What
- Rich metadata: title template, description, keywords, Open Graph, Twitter card, canonical (metadataBase https://txtconv.arpuli.com)
- robots.txt + sitemap.xml via Next metadata routes
- Dynamic OG share image via next/og (edge runtime, no static asset)
- FAQ section (7 Q&As) targeting long-tail queries: 剪映/CapCut 字幕簡轉繁、小說 txt 亂碼、GBK/Big5 編碼、自訂字典、ConvertZ 線上替代 — with FAQPage JSON-LD
- WebApplication JSON-LD with Free/$30 Lifetime offers
- Privacy policy & terms pages (honest wording: conversion is in-browser; uploaded files may be archived), linked in footer

## Verification
- `npx tsc --noEmit`: no new errors (pre-existing jest typing noise only)
- `npx jest --ci`: 13 suites / 163 tests pass
- `npm run build`: green, all new routes emitted
- Live `next start` + curl: title/OG/JSON-LD present, robots + sitemap + /privacy + /terms + /opengraph-image all 200 (PNG)