### PR TITLE
feat: enforce advertised tier file limits (5MB free / 100MB Pro) with upgrade CTA

### DIFF
--- a/__tests__/components/FileUpload.test.tsx
+++ b/__tests__/components/FileUpload.test.tsx
@@ -242,14 +242,63 @@ describe('FileUpload Component', () => {
       await user.upload(input, file);
     }
 
-    // Should show "Failed" status
+    // Should show the actual error message (more useful than a bare "Failed" label)
     await waitFor(() => {
-      expect(screen.getByText('Failed')).toBeInTheDocument();
+      expect(screen.getByText('Conversion failed')).toBeInTheDocument();
     });
 
     // Should have retry button
     await waitFor(() => {
       expect(screen.getByText('refresh')).toBeInTheDocument();
+    });
+  });
+
+  it('should reject files over the free 5MB limit with an upgrade link', async () => {
+    const user = userEvent.setup();
+
+    render(<FileUpload licenseType="free" />);
+
+    const file = new File(['x'], 'novel.txt', { type: 'text/plain' });
+    Object.defineProperty(file, 'size', { value: 10 * 1024 * 1024 });
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    if (input) {
+      await user.upload(input, file);
+    }
+
+    await waitFor(() => {
+      expect(screen.getByText(/超過免費版 5MB 上限/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('link', { name: /升級 Pro/ })).toHaveAttribute('href', '#pricing');
+    // Rejected file must never start converting
+    expect(clientConverter.convertFile).not.toHaveBeenCalled();
+  });
+
+  it('should accept a 10MB file for lifetime users', async () => {
+    const user = userEvent.setup();
+
+    (upload as jest.Mock).mockResolvedValue({
+      url: 'https://blob.vercel-storage.com/file.txt',
+      pathname: 'file-abc123.txt',
+    });
+    (clientConverter.convertFile as jest.Mock).mockResolvedValue({
+      content: '轉換後內容',
+      fileName: 'novel.txt',
+      encoding: 'UTF8',
+    });
+
+    render(<FileUpload licenseType="lifetime" />);
+
+    const file = new File(['x'], 'novel.txt', { type: 'text/plain' });
+    Object.defineProperty(file, 'size', { value: 10 * 1024 * 1024 });
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    if (input) {
+      await user.upload(input, file);
+    }
+
+    await waitFor(() => {
+      expect(clientConverter.convertFile).toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/lib/file-validator.test.ts
+++ b/__tests__/lib/file-validator.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for license-tier-aware file validation: size limits per plan
+ * (Free 5MB / Pro 100MB), upgrade-CTA flagging, and format blocking.
+ */
+import {
+  validateFile,
+  getMaxFileSize,
+  FREE_MAX_FILE_SIZE,
+  PRO_MAX_FILE_SIZE,
+} from '@/lib/file-validator';
+
+/**
+ * Creates a File object of the given byte size without allocating the
+ * full buffer (size is faked via Object.defineProperty for speed).
+ */
+function makeFile(name: string, size: number): File {
+  const file = new File(['x'], name, { type: 'text/plain' });
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+}
+
+describe('getMaxFileSize', () => {
+  it('returns 5MB for free tier and guests (default)', () => {
+    expect(getMaxFileSize('free')).toBe(FREE_MAX_FILE_SIZE);
+    expect(getMaxFileSize()).toBe(FREE_MAX_FILE_SIZE);
+  });
+
+  it('returns 100MB for lifetime and monthly tiers', () => {
+    expect(getMaxFileSize('lifetime')).toBe(PRO_MAX_FILE_SIZE);
+    expect(getMaxFileSize('monthly')).toBe(PRO_MAX_FILE_SIZE);
+  });
+});
+
+describe('validateFile size limits', () => {
+  it('accepts a file under 5MB for free tier', () => {
+    const result = validateFile(makeFile('a.txt', 4 * 1024 * 1024));
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a 10MB file for free tier with upgrade flag', () => {
+    const result = validateFile(makeFile('novel.txt', 10 * 1024 * 1024), 'free');
+    expect(result.valid).toBe(false);
+    expect(result.upgradeAvailable).toBe(true);
+    expect(result.error).toContain('5MB');
+  });
+
+  it('rejects a file over 100MB for free tier without upgrade flag', () => {
+    const result = validateFile(makeFile('huge.txt', 120 * 1024 * 1024), 'free');
+    expect(result.valid).toBe(false);
+    expect(result.upgradeAvailable).toBeUndefined();
+  });
+
+  it('accepts a 10MB file for lifetime tier', () => {
+    const result = validateFile(makeFile('novel.txt', 10 * 1024 * 1024), 'lifetime');
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a file over 100MB for lifetime tier without upgrade flag', () => {
+    const result = validateFile(makeFile('huge.txt', 120 * 1024 * 1024), 'lifetime');
+    expect(result.valid).toBe(false);
+    expect(result.upgradeAvailable).toBeUndefined();
+    expect(result.error).toContain('100MB');
+  });
+
+  it('rejects empty files', () => {
+    const result = validateFile(makeFile('empty.txt', 0));
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('validateFile format blocking', () => {
+  it('rejects blocked extensions regardless of tier', () => {
+    const result = validateFile(makeFile('movie.mp4', 1024), 'lifetime');
+    expect(result.valid).toBe(false);
+  });
+
+  it('accepts srt subtitle files', () => {
+    const result = validateFile(makeFile('subs.srt', 1024));
+    expect(result.valid).toBe(true);
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,7 @@ export default async function Home() {
         </section>
 
         {/* File Upload Section */}
-        <FileUpload />
+        <FileUpload licenseType={profile?.license_type ?? 'free'} />
 
         <CustomDictEditor user={user} profile={profile} />
 

--- a/components/CustomDictEditor.tsx
+++ b/components/CustomDictEditor.tsx
@@ -430,7 +430,17 @@ export default function CustomDictEditor({ user, profile }: CustomDictEditorProp
                   <div className="flex items-center justify-between text-xs">
                     <span className={isOverLimit || isAtLimit ? 'text-red-500 font-medium' : 'text-gray-400'}>
                       {pairCount} / {limit.toLocaleString()} 組對照
-                      {(isOverLimit || isAtLimit) && !isPaid && '（已達上限）'}
+                      {(isOverLimit || isAtLimit) && !isPaid && (
+                        <>
+                          （已達上限）
+                          <a
+                            href="#pricing"
+                            className="ml-1 text-primary hover:text-primary-hover font-bold underline underline-offset-2"
+                          >
+                            升級 Pro 解鎖 10,000 組 →
+                          </a>
+                        </>
+                      )}
                     </span>
                     <span className="text-gray-400">格式：簡體詞,繁體詞</span>
                   </div>

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -16,6 +16,7 @@ import {
   trackFileConversionFailed,
 } from '@/lib/analytics';
 import { createClient } from '@/lib/supabase/client';
+import type { LicenseType } from '@/types/user';
 
 export interface UploadFile {
   id: string;
@@ -29,6 +30,7 @@ export interface UploadFile {
   size: number;
   errMessage: string | null;
   isRetryable: boolean;  // true = server error, false = validation error
+  upgradeAvailable?: boolean;  // rejected only by the free-tier size limit; show upgrade CTA
   convertedContent?: string;
   uploadStartTime?: number;
   conversionStartTime?: number;
@@ -150,9 +152,17 @@ function FileRow({
             {statusText}
           </div>
         ) : isFailed ? (
-          <div className="text-xs text-red-500 font-medium flex items-center gap-1.5">
+          <div className="text-xs text-red-500 font-medium flex items-center gap-1.5 flex-wrap">
             <span className="material-symbols-outlined text-[14px]">error</span>
-            {statusText}
+            <span>{store.errMessage || statusText}</span>
+            {store.upgradeAvailable && (
+              <a
+                href="#pricing"
+                className="text-primary hover:text-primary-hover font-bold underline underline-offset-2"
+              >
+                升級 Pro 可轉換 100MB →
+              </a>
+            )}
           </div>
         ) : (
           <div className="text-xs font-medium text-gray-400 flex items-center gap-1.5">
@@ -195,7 +205,7 @@ function FileRow({
   );
 }
 
-export default function FileUpload() {
+export default function FileUpload({ licenseType = 'free' }: { licenseType?: LicenseType }) {
   const [files, setFiles] = useState<UploadFile[]>([]);
   const [downloadQueue, setDownloadQueue] = useState<Array<{ content: string; fileName: string }>>([]);
   const isProcessingQueue = useRef(false);
@@ -356,7 +366,7 @@ export default function FileUpload() {
   const onDrop = useCallback((acceptedFiles: File[]) => {
     const newFiles: UploadFile[] = acceptedFiles.map((file) => {
       // Validate file using shared validator
-      const validation = validateFile(file);
+      const validation = validateFile(file, licenseType);
 
       return {
         id: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
@@ -370,6 +380,7 @@ export default function FileUpload() {
         size: file.size,
         errMessage: validation.valid ? null : validation.error || 'Invalid file',
         isRetryable: false,  // Validation errors are never retryable
+        upgradeAvailable: validation.upgradeAvailable,
       };
     });
 
@@ -383,7 +394,7 @@ export default function FileUpload() {
         }, index * 100); // Stagger by 100ms
       }
     });
-  }, [convertFile]);
+  }, [convertFile, licenseType]);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,

--- a/components/PricingSection.tsx
+++ b/components/PricingSection.tsx
@@ -14,7 +14,7 @@ export default function PricingSection({
   const isCurrent = (tier: LicenseType) => licenseType === tier;
 
   return (
-    <section className="py-8">
+    <section id="pricing" className="py-8 scroll-mt-8">
       <h3 className="text-3xl font-bold text-center text-gray-800 mb-12">方案價格</h3>
 
       <div className="grid md:grid-cols-3 gap-6">

--- a/e2e/tiered-limits.spec.ts
+++ b/e2e/tiered-limits.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * End-to-end check for license-tier file-size limits: a guest dropping
+ * a file over the free 5MB limit sees the rejection message with an
+ * upgrade link pointing at the pricing section, and no conversion runs.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const BIG_FILE = path.join(
+  '/private/tmp/claude-501/-Users-upchen-Dropbox-01-Projects-08-TxtConv/0c4cc49c-2c6c-42b3-b82a-0a34af1dcf74/scratchpad',
+  'big-novel.txt'
+);
+
+test('guest uploading 9MB file sees free-limit error with upgrade CTA', async ({ page }) => {
+  await page.goto('/');
+
+  await page.setInputFiles('input[type="file"]', BIG_FILE);
+
+  await expect(page.getByText(/超過免費版 5MB 上限/)).toBeVisible();
+
+  const upgradeLink = page.getByRole('link', { name: /升級 Pro 可轉換 100MB/ });
+  await expect(upgradeLink).toBeVisible();
+  await expect(upgradeLink).toHaveAttribute('href', '#pricing');
+
+  // Clicking the CTA lands on the pricing section with the buy button
+  await upgradeLink.click();
+  await expect(page.locator('#pricing')).toBeInViewport();
+  await expect(page.getByRole('link', { name: /立即購買/ })).toBeVisible();
+});
+
+test('small file converts normally for guests', async ({ page }) => {
+  await page.goto('/');
+
+  const smallFile = {
+    name: 'small.txt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('简体软件网络测试'),
+  };
+  await page.setInputFiles('input[type="file"]', smallFile);
+
+  await expect(page.getByText('Finished')).toBeVisible({ timeout: 30000 });
+});

--- a/lib/file-validator.ts
+++ b/lib/file-validator.ts
@@ -1,9 +1,26 @@
 /**
- * File validation utilities
+ * File validation utilities. Size limits are license-tier aware so the
+ * enforced limits match the advertised pricing (Free 5MB / Pro 100MB);
+ * validation runs client-side before conversion starts.
  */
 
-// Validation constants
-export const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25MB
+import type { LicenseType } from '@/types/user';
+
+// Size limit per license tier, matching the published pricing plans.
+export const FREE_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+export const PRO_MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
+
+/**
+ * Returns the maximum allowed file size in bytes for a license tier.
+ *
+ * @param licenseType - User's license tier; guests count as 'free'
+ * @returns Size limit in bytes (5MB free, 100MB monthly/lifetime)
+ */
+export function getMaxFileSize(licenseType: LicenseType = 'free'): number {
+  return licenseType === 'lifetime' || licenseType === 'monthly'
+    ? PRO_MAX_FILE_SIZE
+    : FREE_MAX_FILE_SIZE;
+}
 
 // Block common video and office file extensions
 export const BLOCKED_EXTENSIONS = [
@@ -23,14 +40,24 @@ export const BLOCKED_EXTENSIONS = [
 export interface ValidationResult {
   valid: boolean;
   error?: string;
+  /**
+   * Set when the file was rejected only because of the free-tier size
+   * limit; lets the UI show an upgrade call-to-action instead of a
+   * plain error.
+   */
+  upgradeAvailable?: boolean;
 }
 
 /**
- * Validate uploaded file
+ * Validate uploaded file against format rules and the size limit of
+ * the user's license tier.
+ *
  * @param file - File to validate
- * @returns Validation result
+ * @param licenseType - User's license tier; guests count as 'free'
+ * @returns Validation result; `upgradeAvailable` is true when a larger
+ *   plan would have accepted the file
  */
-export function validateFile(file: File): ValidationResult {
+export function validateFile(file: File, licenseType: LicenseType = 'free'): ValidationResult {
   // Check if file exists
   if (!file) {
     return { valid: false, error: 'No file provided' };
@@ -41,12 +68,21 @@ export function validateFile(file: File): ValidationResult {
     return { valid: false, error: 'File is empty' };
   }
 
-  // Check file size limit
-  if (file.size > MAX_FILE_SIZE) {
-    return {
-      valid: false,
-      error: `File exceeds 25MB limit (${(file.size / 1024 / 1024).toFixed(2)}MB)`,
-    };
+  // Check file size limit for the user's tier
+  const maxSize = getMaxFileSize(licenseType);
+  if (file.size > maxSize) {
+    const sizeMB = (file.size / 1024 / 1024).toFixed(2);
+    const isFreeTier = maxSize === FREE_MAX_FILE_SIZE;
+    return isFreeTier && file.size <= PRO_MAX_FILE_SIZE
+      ? {
+          valid: false,
+          error: `檔案 ${sizeMB}MB 超過免費版 5MB 上限`,
+          upgradeAvailable: true,
+        }
+      : {
+          valid: false,
+          error: `檔案 ${sizeMB}MB 超過 ${isFreeTier ? '5' : '100'}MB 上限`,
+        };
   }
 
   // Block video and office files


### PR DESCRIPTION
## Why
Pricing advertises Free = 5MB and Pro = 100MB, but `lib/file-validator.ts` enforced a flat 25MB for everyone. Free users never felt a limit worth paying for, and Pro buyers didn't receive the promised 100MB — a broken promise in both directions.

## What
- Tier-aware size validation: 5MB for free/guests, 100MB for lifetime/monthly
- Failed rows now show the actual rejection reason (previously a bare 'Failed' label with no explanation)
- Free-tier size rejections include a 「升級 Pro 可轉換 100MB →」 link to the pricing section
- Custom-dictionary 5-entry limit now links to pricing too
- Note: /api/upload archive route keeps its own 25MB cap — archive failure is non-fatal, and that route is pending the public-blob privacy decision

## Verification
- `npx jest --ci`: 14 suites / 175 tests pass (new validator + upsell tests)
- `npm run build`: green
- Playwright e2e in real Chromium: guest 9MB upload → rejection message + CTA visible → click scrolls to #pricing with buy button; small file still converts to Finished