### PR TITLE
feat: SEO landing pages /srt and /novel

### DIFF
--- a/app/novel/page.tsx
+++ b/app/novel/page.tsx
@@ -1,0 +1,126 @@
+import type { Metadata } from 'next';
+import FileUpload from '@/components/FileUpload';
+import Footer from '@/components/Footer';
+import Header from '@/components/Header';
+import { getAuthUser, getProfile } from '@/lib/actions/auth';
+
+/**
+ * SEO landing page for novel/text-file conversion queries (小說 txt 簡轉繁,
+ * 簡體亂碼修復). Hosts the in-browser converter with novel-specific guidance
+ * — encoding auto-detection is the differentiator this page explains.
+ */
+
+export const metadata: Metadata = {
+  title: '小說 TXT 簡轉繁 — 簡體亂碼自動修復、轉台灣用語',
+  description:
+    '簡體小說 txt 免費線上轉繁體：自動偵測 GBK/GB18030/Big5 編碼修復亂碼，轉成台灣慣用詞，支援批次與大檔案。自訂字典可固定人名譯法。',
+  alternates: { canonical: '/novel' },
+  openGraph: {
+    title: '小說 TXT 簡轉繁 — 簡體亂碼自動修復、轉台灣用語',
+    description:
+      '簡體小說 txt 免費線上轉繁體：自動偵測編碼修復亂碼，轉成台灣慣用詞，支援批次轉換。',
+    url: 'https://txtconv.arpuli.com/novel',
+  },
+};
+
+const NOVEL_FAQ = [
+  {
+    question: '下載的簡體小說打開全是亂碼，為什麼？',
+    answer:
+      '簡體小說 txt 大多以 GBK 或 GB18030 編碼儲存，而台灣的系統預設用 Big5 或 UTF-8 開啟，編碼對不上就變亂碼。txtconv 會自動偵測正確編碼再轉換，輸出一律是 UTF-8 繁體中文，手機、電腦、電子書閱讀器都能正常開啟。',
+  },
+  {
+    question: '小說人名、專有名詞轉錯了怎麼辦？',
+    answer:
+      '登入後可使用自訂字典：每行一組「簡體詞,繁體詞」，例如「昆仑,崑崙」。自訂字典的優先度高於預設規則，適合固定人名、地名、招式名的譯法。免費版可設定 5 組，Pro 版最多 10,000 組。',
+  },
+  {
+    question: '整套小說幾十個檔案，要一個一個轉嗎？',
+    answer:
+      '不用。把所有 txt 檔一次拖進轉換區即可批次轉換。免費版單檔上限 5MB（一般長篇小說約 1-3MB），更大的合集檔可升級 Pro 支援單檔 100MB。',
+  },
+];
+
+export default async function NovelLandingPage() {
+  const user = await getAuthUser();
+  const profile = user ? await getProfile(user.id) : null;
+
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: NOVEL_FAQ.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: { '@type': 'Answer', text: item.answer },
+    })),
+  };
+
+  return (
+    <>
+      <Header user={user} profile={profile} />
+
+      <main className="flex-1 max-w-5xl mx-auto w-full px-6 py-12 flex flex-col gap-12">
+        <section className="space-y-6">
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-800 leading-snug">
+            小說 TXT 簡轉繁：亂碼自動修復，轉成台灣用語
+          </h1>
+          <p className="text-lg text-gray-600 max-w-4xl">
+            簡體小說打開是亂碼？txtconv 自動偵測 GBK / GB18030 / Big5
+            編碼，正確解碼後轉成台灣慣用的繁體中文（软件→軟體、网络→網路），
+            並輸出成任何裝置都能開的 UTF-8。支援整套小說批次轉換。
+          </p>
+        </section>
+
+        <FileUpload licenseType={profile?.license_type ?? 'free'} />
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold text-gray-800">為什麼選 txtconv 轉小說</h2>
+          <ul className="list-disc pl-6 space-y-2 text-gray-600">
+            <li>亂碼救援：自動判斷來源編碼，不用自己猜是 GBK 還是 Big5</li>
+            <li>台灣用語：OpenCC 詞庫轉換，不是逐字替換，讀起來自然</li>
+            <li>自訂字典：人名、地名、招式名可固定譯法，整套書一致</li>
+            <li>免安裝：瀏覽器就能用，Mac 也不用找 ConvertZ 替代品</li>
+          </ul>
+          <p className="text-gray-600">
+            要轉影片字幕？請見{' '}
+            <a href="/srt" className="text-primary hover:underline">
+              SRT 字幕簡轉繁
+            </a>
+            ，或回到
+            <a href="/" className="text-primary hover:underline">
+              首頁
+            </a>
+            查看完整功能與方案。
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold text-gray-800">小說轉換常見問題</h2>
+          <div className="space-y-4">
+            {NOVEL_FAQ.map((item) => (
+              <details
+                key={item.question}
+                className="group bg-white rounded-2xl shadow-sm border border-gray-100 px-6 py-4"
+              >
+                <summary className="cursor-pointer list-none flex items-center justify-between gap-4 font-medium text-gray-800">
+                  <h3 className="text-base font-medium">{item.question}</h3>
+                  <span className="material-symbols-outlined text-gray-400 transition-transform group-open:rotate-180">
+                    expand_more
+                  </span>
+                </summary>
+                <p className="mt-3 text-sm leading-relaxed text-gray-600">{item.answer}</p>
+              </details>
+            ))}
+          </div>
+        </section>
+
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        />
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,8 +31,16 @@ export default async function Home() {
           </p>
           <div className="space-y-1 text-sm text-gray-500">
             <p>支援檔案格式為：</p>
-            <p>.txt 純文字小說檔案</p>
-            <p>.srt 電影字幕檔案</p>
+            <p>
+              <a href="/novel" className="hover:text-primary underline underline-offset-2">
+                .txt 純文字小說檔案
+              </a>
+            </p>
+            <p>
+              <a href="/srt" className="hover:text-primary underline underline-offset-2">
+                .srt 電影字幕檔案
+              </a>
+            </p>
             <p>.csv 資料格式</p>
             <p>.xml 資料格式</p>
           </div>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -15,6 +15,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
     },
     {
+      url: `${base}/srt`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${base}/novel`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
       url: `${base}/privacy`,
       changeFrequency: 'yearly',
       priority: 0.3,

--- a/app/srt/page.tsx
+++ b/app/srt/page.tsx
@@ -1,0 +1,126 @@
+import type { Metadata } from 'next';
+import FileUpload from '@/components/FileUpload';
+import Footer from '@/components/Footer';
+import Header from '@/components/Header';
+import { getAuthUser, getProfile } from '@/lib/actions/auth';
+
+/**
+ * SEO landing page for subtitle conversion queries (剪映/CapCut 字幕簡轉繁,
+ * srt 簡體轉繁體). Hosts the same in-browser converter as the homepage with
+ * subtitle-specific guidance so the page ranks for and directly serves
+ * subtitle-related searches.
+ */
+
+export const metadata: Metadata = {
+  title: 'SRT 字幕簡轉繁 — 剪映/CapCut 字幕一鍵轉繁體',
+  description:
+    '剪映、CapCut 匯出的 .srt 字幕免費線上轉繁體中文：拖曳上傳即轉換，時間軸不變，自動轉台灣用語（软件→軟體、视频→影片）。瀏覽器內完成，速度快。',
+  alternates: { canonical: '/srt' },
+  openGraph: {
+    title: 'SRT 字幕簡轉繁 — 剪映/CapCut 字幕一鍵轉繁體',
+    description:
+      '剪映、CapCut 匯出的 .srt 字幕免費線上轉繁體中文，時間軸不變，自動轉台灣用語。',
+    url: 'https://txtconv.arpuli.com/srt',
+  },
+};
+
+const SUBTITLE_FAQ = [
+  {
+    question: '剪映匯出的字幕轉繁體後，時間軸會跑掉嗎？',
+    answer:
+      '不會。txtconv 只轉換字幕的文字內容，SRT 的序號與時間碼（例如 00:00:01,000 --> 00:00:03,500）完全保持原樣，轉完直接匯入剪輯軟體或播放器即可使用。',
+  },
+  {
+    question: '為什麼不直接用剪輯軟體內建的簡繁轉換？',
+    answer:
+      '多數剪輯軟體沒有簡繁轉換，或只做逐字替換，會留下「软件、视频、信息」這類直翻詞。txtconv 使用 OpenCC 台灣正體詞庫，會轉成台灣觀眾習慣的「軟體、影片、資訊」，字幕看起來更自然。',
+  },
+  {
+    question: '批次處理多集影片的字幕可以嗎？',
+    answer:
+      '可以。一次拖入多個 .srt 檔案，txtconv 會依序自動轉換，每個檔案轉完即可下載，適合整季影集或系列影片的字幕處理。',
+  },
+];
+
+export default async function SrtLandingPage() {
+  const user = await getAuthUser();
+  const profile = user ? await getProfile(user.id) : null;
+
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: SUBTITLE_FAQ.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: { '@type': 'Answer', text: item.answer },
+    })),
+  };
+
+  return (
+    <>
+      <Header user={user} profile={profile} />
+
+      <main className="flex-1 max-w-5xl mx-auto w-full px-6 py-12 flex flex-col gap-12">
+        <section className="space-y-6">
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-800 leading-snug">
+            SRT 字幕簡轉繁：剪映、CapCut 字幕一鍵轉台灣繁體
+          </h1>
+          <p className="text-lg text-gray-600 max-w-4xl">
+            剪映（CapCut）辨識出來的字幕常是簡體中文。把 .srt
+            檔拖進下方轉換區，txtconv 立刻在瀏覽器內轉成台灣用語的繁體中文
+            —— 時間軸與序號完全不動，轉完就能直接用。
+          </p>
+        </section>
+
+        <FileUpload licenseType={profile?.license_type ?? 'free'} />
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold text-gray-800">三步驟完成字幕轉換</h2>
+          <ol className="list-decimal pl-6 space-y-2 text-gray-600">
+            <li>從剪映/CapCut 或字幕軟體匯出 .srt 字幕檔</li>
+            <li>拖曳（或點選）上傳到本頁的轉換區，自動開始轉換</li>
+            <li>點下載取得繁體字幕，直接匯回剪輯軟體或播放器</li>
+          </ol>
+          <p className="text-gray-600">
+            也需要轉換小說或其他文字檔？請見{' '}
+            <a href="/novel" className="text-primary hover:underline">
+              小說 TXT 簡轉繁
+            </a>
+            ，或回到
+            <a href="/" className="text-primary hover:underline">
+              首頁
+            </a>
+            查看完整功能與方案。
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold text-gray-800">字幕轉換常見問題</h2>
+          <div className="space-y-4">
+            {SUBTITLE_FAQ.map((item) => (
+              <details
+                key={item.question}
+                className="group bg-white rounded-2xl shadow-sm border border-gray-100 px-6 py-4"
+              >
+                <summary className="cursor-pointer list-none flex items-center justify-between gap-4 font-medium text-gray-800">
+                  <h3 className="text-base font-medium">{item.question}</h3>
+                  <span className="material-symbols-outlined text-gray-400 transition-transform group-open:rotate-180">
+                    expand_more
+                  </span>
+                </summary>
+                <p className="mt-3 text-sm leading-relaxed text-gray-600">{item.answer}</p>
+              </details>
+            ))}
+          </div>
+        </section>
+
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        />
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/e2e/tiered-limits.spec.ts
+++ b/e2e/tiered-limits.spec.ts
@@ -28,6 +28,19 @@ test('guest uploading 9MB file sees free-limit error with upgrade CTA', async ({
   await expect(page.getByRole('link', { name: /立即購買/ })).toBeVisible();
 });
 
+test('converter works on the /srt landing page', async ({ page }) => {
+  await page.goto('/srt');
+
+  const srtFile = {
+    name: 'subs.srt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('1\n00:00:01,000 --> 00:00:03,500\n简体软件测试\n'),
+  };
+  await page.setInputFiles('input[type="file"]', srtFile);
+
+  await expect(page.getByText('Finished')).toBeVisible({ timeout: 30000 });
+});
+
 test('small file converts normally for guests', async ({ page }) => {
   await page.goto('/');
 


### PR DESCRIPTION
## Why
The site is one page; it can't rank for both 字幕 (subtitle) and 小說/亂碼 (novel/encoding) query families at once. Dedicated pages with the converter embedded serve searchers directly and multiply organic surface.

## What
- /srt: 剪映/CapCut subtitle conversion page — timeline-preservation and Taiwan-wording answers
- /novel: novel txt conversion page — GBK/Big5 encoding auto-detect (亂碼修復) story + custom-dictionary pitch
- Unique FAQ + FAQPage JSON-LD per page, cross-links, homepage hero links, sitemap entries

## Verification
- 175 unit tests pass; build green (routes /srt /novel emitted)
- Live `next start`: titles/H1/JSON-LD verified via curl on both pages; sitemap contains both; homepage links present
- Playwright e2e: real .srt file converts to Finished on /srt; existing guest-limit and homepage tests still pass (3/3)