### PR TITLE
feat: checkout-funnel analytics events

### DIFF
--- a/components/CustomDictEditor.tsx
+++ b/components/CustomDictEditor.tsx
@@ -435,6 +435,7 @@ export default function CustomDictEditor({ user, profile }: CustomDictEditorProp
                           （已達上限）
                           <a
                             href="#pricing"
+                            onClick={() => trackUpgradeCtaClicked('dict_limit')}
                             className="ml-1 text-primary hover:text-primary-hover font-bold underline underline-offset-2"
                           >
                             升級 Pro 解鎖 10,000 組 →

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -14,6 +14,7 @@ import {
   trackFileConversionStarted,
   trackFileConversionCompleted,
   trackFileConversionFailed,
+  trackUpgradeCtaClicked,
 } from '@/lib/analytics';
 import { createClient } from '@/lib/supabase/client';
 import type { LicenseType } from '@/types/user';
@@ -158,6 +159,7 @@ function FileRow({
             {store.upgradeAvailable && (
               <a
                 href="#pricing"
+                onClick={() => trackUpgradeCtaClicked('file_size_limit')}
                 className="text-primary hover:text-primary-hover font-bold underline underline-offset-2"
               >
                 升級 Pro 可轉換 100MB →

--- a/components/PricingSection.tsx
+++ b/components/PricingSection.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { trackBeginCheckout } from '@/lib/analytics';
 import type { LicenseType } from '@/types/user';
 
 interface PricingSectionProps {
@@ -127,6 +128,7 @@ export default function PricingSection({
               href={gumroadUrl}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => trackBeginCheckout(30, 'lifetime')}
               className="w-full py-3 px-4 bg-primary hover:bg-primary-hover text-white font-bold rounded-lg transition-colors flex items-center justify-center gap-2"
             >
               立即購買 →

--- a/e2e/tiered-limits.spec.ts
+++ b/e2e/tiered-limits.spec.ts
@@ -25,7 +25,17 @@ test('guest uploading 9MB file sees free-limit error with upgrade CTA', async ({
   // Clicking the CTA lands on the pricing section with the buy button
   await upgradeLink.click();
   await expect(page.locator('#pricing')).toBeInViewport();
-  await expect(page.getByRole('link', { name: /立即購買/ })).toBeVisible();
+  const buyButton = page.getByRole('link', { name: /立即購買/ });
+  await expect(buyButton).toBeVisible();
+
+  // Funnel events reach the GTM dataLayer
+  await buyButton.click();
+  const events = await page.evaluate(() =>
+    (window as unknown as { dataLayer: Array<{ event: string }> }).dataLayer
+      .map((e) => e.event)
+  );
+  expect(events).toContain('upgrade_cta_clicked');
+  expect(events).toContain('begin_checkout');
 });
 
 test('converter works on the /srt landing page', async ({ page }) => {

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -10,6 +10,8 @@ import type {
   FileConversionStartedEvent,
   FileConversionCompletedEvent,
   FileConversionFailedEvent,
+  BeginCheckoutEvent,
+  UpgradeCtaClickedEvent,
 } from '@/types/gtm';
 
 /**
@@ -177,6 +179,49 @@ export function trackFileConversionFailed(
     error_type: errorType,
     error_message: sanitizeErrorMessage(errorMessage),
     input_encoding: inputEncoding,
+  };
+
+  window.dataLayer.push(event);
+}
+
+/**
+ * Track a click on a "buy" button that hands off to Gumroad checkout.
+ * Fired before navigation; measures how many visitors reach checkout,
+ * which pages drive purchases, and (vs. Gumroad sales) checkout drop-off.
+ *
+ * @param value - Price shown to the user (USD)
+ * @param itemName - Product/plan name (e.g. "lifetime")
+ */
+export function trackBeginCheckout(value: number, itemName: string): void {
+  ensureDataLayer();
+
+  const event: BeginCheckoutEvent = {
+    event: 'begin_checkout',
+    currency: 'USD',
+    value,
+    item_name: itemName,
+    source_path: window.location.pathname,
+  };
+
+  window.dataLayer.push(event);
+}
+
+/**
+ * Track a click on an in-context upgrade call-to-action (shown when a
+ * free-tier limit is hit). Measures which limit actually drives
+ * upgrade intent.
+ *
+ * @param ctaSource - Which limit surfaced the CTA
+ */
+export function trackUpgradeCtaClicked(
+  ctaSource: 'file_size_limit' | 'dict_limit'
+): void {
+  ensureDataLayer();
+
+  const event: UpgradeCtaClickedEvent = {
+    event: 'upgrade_cta_clicked',
+    cta_source: ctaSource,
+    source_path: window.location.pathname,
   };
 
   window.dataLayer.push(event);

--- a/types/gtm.d.ts
+++ b/types/gtm.d.ts
@@ -53,13 +53,31 @@ export interface FileConversionFailedEvent {
   input_encoding: string;
 }
 
+export interface BeginCheckoutEvent {
+  event: 'begin_checkout';
+  currency: string;
+  value: number;
+  item_name: string;
+  /** Page path where the buy button was clicked (e.g. "/", "/srt") */
+  source_path: string;
+}
+
+export interface UpgradeCtaClickedEvent {
+  event: 'upgrade_cta_clicked';
+  /** Which limit triggered the CTA the user clicked */
+  cta_source: 'file_size_limit' | 'dict_limit';
+  source_path: string;
+}
+
 export type DataLayerEvent =
   | FileUploadStartedEvent
   | FileUploadCompletedEvent
   | FileUploadFailedEvent
   | FileConversionStartedEvent
   | FileConversionCompletedEvent
-  | FileConversionFailedEvent;
+  | FileConversionFailedEvent
+  | BeginCheckoutEvent
+  | UpgradeCtaClickedEvent;
 
 declare global {
   interface Window {


### PR DESCRIPTION
## Why
No visibility into purchase intent — a sale is only observable after Gumroad completes. begin_checkout vs. Gumroad sales gives checkout drop-off, and source_path attributes purchases to pages (/, /srt, /novel). Needed to judge the $30 price with data.

## What
- `begin_checkout` GTM dataLayer event on the Lifetime 立即購買 click (value 30/USD, source_path)
- `upgrade_cta_clicked` on both free-limit CTAs (cta_source: file_size_limit | dict_limit)
- Typed in types/gtm.d.ts following existing event patterns

## Verification
- 175 unit tests pass; build green
- Playwright e2e (real Chromium): 9MB rejection → CTA click → buy click → asserts both events present in window.dataLayer (3/3 pass)

Note: GTM container needs matching triggers/tags for GA4 forwarding — I can't access GTM-TWV35322; events are queued in dataLayer regardless.