### PR TITLE
feat: homepage trust row + media mentions; fix master build (missing analytics import)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,6 +29,32 @@ export default async function Home() {
           <p className="text-lg text-gray-600 max-w-4xl">
             線上免費將剪映 Capcut 字幕、小說、電子書、CSV 等文字檔從簡體轉換成繁體中文，支援批次轉換。
           </p>
+
+          {/* Trust row: three quick reassurances shown right under the hero copy.
+              Kept as a lightweight icon+text row (not a card section) so it
+              supports the conversion decision without pushing the uploader
+              below the fold. */}
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-gray-600">
+            <span className="flex items-center gap-1.5">
+              <span className="material-symbols-outlined text-primary text-lg" aria-hidden="true">
+                check_circle
+              </span>
+              免費使用
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="material-symbols-outlined text-primary text-lg" aria-hidden="true">
+                devices
+              </span>
+              免安裝、瀏覽器內完成
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="material-symbols-outlined text-primary text-lg" aria-hidden="true">
+                manage_search
+              </span>
+              自動偵測編碼
+            </span>
+          </div>
+
           <div className="space-y-1 text-sm text-gray-500">
             <p>支援檔案格式為：</p>
             <p>
@@ -44,6 +70,29 @@ export default async function Home() {
             <p>.csv 資料格式</p>
             <p>.xml 資料格式</p>
           </div>
+
+          {/* Social proof: real third-party coverage only — do not add outlets
+              that have not actually reviewed txtconv. */}
+          <p className="text-sm text-gray-400">
+            媒體報導：
+            <a
+              href="https://briian.com/27849/txtconv.html"
+              target="_blank"
+              rel="noopener"
+              className="hover:text-primary underline underline-offset-2"
+            >
+              重灌狂人
+            </a>
+            <span aria-hidden="true">・</span>
+            <a
+              href="https://www.techmarks.com/convert-zh-cn/"
+              target="_blank"
+              rel="noopener"
+              className="hover:text-primary underline underline-offset-2"
+            >
+              TechMarks
+            </a>
+          </p>
         </section>
 
         {/* File Upload Section */}

--- a/components/CustomDictEditor.tsx
+++ b/components/CustomDictEditor.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/lib/custom-dict';
 import { isPaidUser } from '@/lib/auth';
 import { updateDictCache } from '@/lib/client-converter';
+import { trackUpgradeCtaClicked } from '@/lib/analytics';
 
 interface CustomDictEditorProps {
   user: User | null;


### PR DESCRIPTION
## What

1. **Fix (build blocker on master):** `components/CustomDictEditor.tsx` used `trackUpgradeCtaClicked` without importing it, so `npm run build` fails on master. This means the checkout-funnel events PR (#76) **never deployed to production** — prod JS chunks contain no `begin_checkout` string. One-line import fix.
2. **Homepage conversion polish** (`app/page.tsx`):
   - Trust row under the hero: 免費使用 / 免安裝、瀏覽器內完成 / 自動偵測編碼 (Material Symbols icon + text, matches existing gray palette + text-primary accents).
   - Subtle 媒體報導 line linking the two real third-party reviews: 重灌狂人 (briian.com/27849/txtconv.html) and TechMarks (techmarks.com/convert-zh-cn/), both `target="_blank" rel="noopener"`. No invented press, counts, or testimonials.

## Verification

- `npx jest --ci` — 175/175 tests pass (the one "failed suite" is jest picking up `e2e/tiered-limits.spec.ts`, a Playwright file — pre-existing config quirk, unrelated).
- `npm run build` — compiles successfully after the import fix (fails on master without it).
- Live check: `next start -p 3100` + curl `/` — served HTML contains 免費使用 / 免安裝、瀏覽器內完成 / 自動偵測編碼 / 媒體報導 / both outlet links with `rel="noopener"`.
- `npx playwright test e2e/tiered-limits.spec.ts` — 3/3 passed (guest 9MB limit error + CTA, /srt converter, small-file conversion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)