### PR TITLE
ci: add PR build + test gate via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+# CI gate for pull requests: install, build, and run the jest suite.
+# Deploys are handled by Vercel on merge to master, so no deploy steps here.
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run unit tests
+        run: npx jest --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    env:
+      # Placeholder values so `next build` can prerender pages that construct
+      # a Supabase client (e.g. /auth/auth-code-error). No real backend is
+      # contacted during build or unit tests; production values live in Vercel.
+      NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-placeholder-anon-key
     steps:
       - uses: actions/checkout@v4
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,9 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
+  // Playwright specs live in e2e/ and must not run under jest — they import
+  // @playwright/test, whose runner conflicts with jest's and fails the suite.
+  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/', '<rootDir>/e2e/'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     '^opencc-js$': '<rootDir>/lib/__mocks__/opencc-js.ts',


### PR DESCRIPTION
## Why

Master recently sat broken for a full iteration: PR #76 merged a component change with a missing import, `npm run build` failed on master, and nothing deployed until iteration 5 caught it. There was no build gate on PRs.

## What

- **`.github/workflows/ci.yml`** — on every pull request: checkout, setup-node 20 (npm cache), `npm ci`, `npm run build`, `npx jest --ci`. Minimal by design; Vercel keeps owning deploys, and no `tsc --noEmit` step (pre-existing jest-typing noise in test files fails it).
- **`jest.config.js`** — adds `testPathIgnorePatterns` for `e2e/` (plus the node_modules/.next defaults) so jest no longer picks up the Playwright spec `e2e/tiered-limits.spec.ts` and fails; Playwright tests still run via `npx playwright test`.

## Verification

- `npx jest --ci` — 14 suites, 175/175 tests pass (e2e suite no longer collected; `npx jest --listTests` shows 14 files, zero under e2e/)
- `npm run build` — compiles successfully
- Workflow YAML validated with `python3 -c "yaml.safe_load(...)"` — parses OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)