### PR TITLE
ci: bump actions/checkout and actions/setup-node to v5; reconcile audit debt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,11 @@ jobs:
       NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-placeholder-anon-key
     steps:
-      - uses: actions/checkout@v4
+      # v5 of both actions runs on the Node 24 action runtime, clearing the
+      # "Node 20 actions runtime is deprecated" warning that v4 emits.
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## What

Bumps `.github/workflows/ci.yml` from `actions/checkout@v4` / `actions/setup-node@v4` to `@v5`. v5 of both actions runs on the Node 24 action runtime, clearing the "Node 20 actions runtime is deprecated" warning on every CI run. (v5 tags verified to exist on both repos.)

## Audit-debt reconciliation (no code change needed)

**Dependabot shows 15 open alerts; local `npm audit` shows 2. Both are correct — they count differently:**

- Dependabot counts **per advisory**: 14 GHSA advisories against `next` (all fixed in >= 15.0.8–15.5.16) + 1 against `postcss` (< 8.5.10) = 15.
- `npm audit` groups **per package**: 1 high entry for `next` (containing all 14 advisories) + 1 moderate for `postcss` = 2.

**Why neither is fixed here:**

- `next` 14.2.35 → fix requires >= 15.5.16 (semver **major** of a runtime dependency). Deliberately not bumped — owner decision required for a Next 15/16 migration. Dependabot PR #79 (next 16.2.10, CI green) is left open as the migration vehicle when the owner approves.
- The vulnerable `postcss` is **next's own exact-pinned nested copy** (`next@14.2.35` depends on `postcss@8.4.31`); the project's top-level postcss is already 8.5.16. Only a next major (or a risky override against next's exact pin) resolves it, so it rides along with the next decision.

**Obsolete dependabot PRs closed** (master already contains newer versions via PR #82's audit fix): #71 (ws 8.21.0 — already in lockfile), #68 (postcss 8.5.10 — top-level already at 8.5.16).

## Verification

- `npm ci` clean
- `npx jest --ci`: 175/175 (14 suites)
- `npm run build`: green
- `npx playwright test`: 8/8
- CI on this PR exercises the bumped actions themselves

🤖 Generated with [Claude Code](https://claude.com/claude-code)