### PR TITLE
feat: add file_rejected analytics event for the paywall funnel step

### DIFF
--- a/__tests__/components/FileUpload.test.tsx
+++ b/__tests__/components/FileUpload.test.tsx
@@ -36,6 +36,8 @@ describe('FileUpload Component', () => {
     (global.fetch as jest.Mock).mockClear();
     mockClick.mockClear();
     (clientConverter.convertFile as jest.Mock).mockClear();
+    // Reset the GTM dataLayer so each test asserts only its own events
+    window.dataLayer = [];
   });
 
   it('should render upload dropzone with original text', () => {
@@ -229,6 +231,35 @@ describe('FileUpload Component', () => {
     expect(screen.getByRole('link', { name: /升級 Pro/ })).toHaveAttribute('href', '#pricing');
     // Rejected file must never start converting
     expect(clientConverter.convertFile).not.toHaveBeenCalled();
+  });
+
+  it('should push a file_rejected dataLayer event on an oversized drop', async () => {
+    const user = userEvent.setup();
+
+    render(<FileUpload licenseType="free" />);
+
+    const file = new File(['x'], 'novel.txt', { type: 'text/plain' });
+    Object.defineProperty(file, 'size', { value: 9 * 1024 * 1024 });
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    if (input) {
+      await user.upload(input, file);
+    }
+
+    await waitFor(() => {
+      expect(screen.getByText(/超過免費版 5MB 上限/)).toBeInTheDocument();
+    });
+
+    const rejectedEvents = window.dataLayer.filter((e) => e.event === 'file_rejected');
+    expect(rejectedEvents).toHaveLength(1);
+    expect(rejectedEvents[0]).toMatchObject({
+      event: 'file_rejected',
+      file_size: 9 * 1024 * 1024,
+      file_type: '.txt',
+      reject_reason: 'size_limit_free',
+      upgrade_available: true,
+      source_path: '/',
+    });
   });
 
   it('should accept a 10MB file for lifetime users', async () => {

--- a/__tests__/lib/file-validator.test.ts
+++ b/__tests__/lib/file-validator.test.ts
@@ -37,17 +37,19 @@ describe('validateFile size limits', () => {
     expect(result.valid).toBe(true);
   });
 
-  it('rejects a 10MB file for free tier with upgrade flag', () => {
+  it('rejects a 10MB file for free tier with upgrade flag and size_limit_free reason', () => {
     const result = validateFile(makeFile('novel.txt', 10 * 1024 * 1024), 'free');
     expect(result.valid).toBe(false);
     expect(result.upgradeAvailable).toBe(true);
     expect(result.error).toContain('5MB');
+    expect(result.reason).toBe('size_limit_free');
   });
 
-  it('rejects a file over 100MB for free tier without upgrade flag', () => {
+  it('rejects a file over 100MB for free tier without upgrade flag (size_limit_pro reason)', () => {
     const result = validateFile(makeFile('huge.txt', 120 * 1024 * 1024), 'free');
     expect(result.valid).toBe(false);
     expect(result.upgradeAvailable).toBeUndefined();
+    expect(result.reason).toBe('size_limit_pro');
   });
 
   it('accepts a 10MB file for lifetime tier', () => {
@@ -55,23 +57,32 @@ describe('validateFile size limits', () => {
     expect(result.valid).toBe(true);
   });
 
-  it('rejects a file over 100MB for lifetime tier without upgrade flag', () => {
+  it('rejects a file over 100MB for lifetime tier without upgrade flag (size_limit_pro reason)', () => {
     const result = validateFile(makeFile('huge.txt', 120 * 1024 * 1024), 'lifetime');
     expect(result.valid).toBe(false);
     expect(result.upgradeAvailable).toBeUndefined();
     expect(result.error).toContain('100MB');
+    expect(result.reason).toBe('size_limit_pro');
   });
 
-  it('rejects empty files', () => {
+  it('rejects empty files with empty reason', () => {
     const result = validateFile(makeFile('empty.txt', 0));
     expect(result.valid).toBe(false);
+    expect(result.reason).toBe('empty');
+  });
+
+  it('leaves reason unset on valid files', () => {
+    const result = validateFile(makeFile('ok.txt', 1024));
+    expect(result.valid).toBe(true);
+    expect(result.reason).toBeUndefined();
   });
 });
 
 describe('validateFile format blocking', () => {
-  it('rejects blocked extensions regardless of tier', () => {
+  it('rejects blocked extensions regardless of tier with blocked_type reason', () => {
     const result = validateFile(makeFile('movie.mp4', 1024), 'lifetime');
     expect(result.valid).toBe(false);
+    expect(result.reason).toBe('blocked_type');
   });
 
   it('accepts srt subtitle files', () => {

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -11,6 +11,7 @@ import {
   trackFileConversionStarted,
   trackFileConversionCompleted,
   trackFileConversionFailed,
+  trackFileRejected,
   trackUpgradeCtaClicked,
 } from '@/lib/analytics';
 import { createClient } from '@/lib/supabase/client';
@@ -340,6 +341,17 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
     const newFiles: UploadFile[] = acceptedFiles.map((file) => {
       // Validate file using shared validator
       const validation = validateFile(file, licenseType);
+
+      // Report rejections to GA4 — the free 5MB rejection is the funnel's
+      // paywall moment. Falls back to 'blocked_type' for legacy results
+      // without a machine-readable reason.
+      if (!validation.valid) {
+        trackFileRejected(
+          file,
+          validation.reason ?? 'blocked_type',
+          validation.upgradeAvailable === true
+        );
+      }
 
       return {
         id: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,

--- a/e2e/tiered-limits.spec.ts
+++ b/e2e/tiered-limits.spec.ts
@@ -18,6 +18,19 @@ test('guest uploading 9MB file sees free-limit error with upgrade CTA', async ({
 
   await expect(page.getByText(/超過免費版 5MB 上限/)).toBeVisible();
 
+  // The rejection itself must be measurable: a file_rejected event with
+  // the free-limit reason reaches the GTM dataLayer.
+  const rejectedEvents = await page.evaluate(() =>
+    (window as unknown as { dataLayer: Array<Record<string, unknown>> }).dataLayer
+      .filter((e) => e.event === 'file_rejected')
+  );
+  expect(rejectedEvents).toHaveLength(1);
+  expect(rejectedEvents[0]).toMatchObject({
+    reject_reason: 'size_limit_free',
+    upgrade_available: true,
+    source_path: '/',
+  });
+
   const upgradeLink = page.getByRole('link', { name: /升級 Pro 可轉換 100MB/ });
   await expect(upgradeLink).toBeVisible();
   await expect(upgradeLink).toHaveAttribute('href', '#pricing');

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -9,6 +9,7 @@ import type {
   FileConversionStartedEvent,
   FileConversionCompletedEvent,
   FileConversionFailedEvent,
+  FileRejectedEvent,
   BeginCheckoutEvent,
   UpgradeCtaClickedEvent,
 } from '@/types/gtm';
@@ -117,6 +118,36 @@ export function trackFileConversionFailed(
     error_type: errorType,
     error_message: sanitizeErrorMessage(errorMessage),
     input_encoding: inputEncoding,
+  };
+
+  window.dataLayer.push(event);
+}
+
+/**
+ * Track a file rejected by pre-conversion validation (size limit,
+ * blocked type, or empty file). The free 5MB size rejection is the
+ * exact moment upgrade necessity appears, so this event makes the
+ * paywall step of the funnel measurable in GA4.
+ *
+ * @param file - The rejected file (only size and extension are sent)
+ * @param reason - Machine-readable rejection cause from the validator
+ * @param upgradeAvailable - True when a larger paid plan would have
+ *   accepted the file
+ */
+export function trackFileRejected(
+  file: File,
+  reason: FileRejectedEvent['reject_reason'],
+  upgradeAvailable: boolean
+): void {
+  ensureDataLayer();
+
+  const event: FileRejectedEvent = {
+    event: 'file_rejected',
+    file_size: file.size,
+    file_type: getFileExtension(file.name),
+    reject_reason: reason,
+    upgrade_available: upgradeAvailable,
+    source_path: window.location.pathname,
   };
 
   window.dataLayer.push(event);

--- a/lib/file-validator.ts
+++ b/lib/file-validator.ts
@@ -37,9 +37,23 @@ export const BLOCKED_EXTENSIONS = [
   '.mp3', '.wav', '.flac', '.aac', '.ogg',
 ];
 
+/**
+ * Machine-readable rejection cause, used for analytics (`file_rejected`
+ * dataLayer event). 'size_limit_free' means the free 5MB limit was hit
+ * but a Pro plan would accept the file; 'size_limit_pro' means the file
+ * exceeds the 100MB hard ceiling of every plan.
+ */
+export type FileRejectReason =
+  | 'size_limit_free'
+  | 'size_limit_pro'
+  | 'blocked_type'
+  | 'empty';
+
 export interface ValidationResult {
   valid: boolean;
   error?: string;
+  /** Machine-readable rejection cause; set on every rejection of a real file. */
+  reason?: FileRejectReason;
   /**
    * Set when the file was rejected only because of the free-tier size
    * limit; lets the UI show an upgrade call-to-action instead of a
@@ -55,7 +69,8 @@ export interface ValidationResult {
  * @param file - File to validate
  * @param licenseType - User's license tier; guests count as 'free'
  * @returns Validation result; `upgradeAvailable` is true when a larger
- *   plan would have accepted the file
+ *   plan would have accepted the file, and `reason` carries the
+ *   machine-readable rejection cause for analytics
  */
 export function validateFile(file: File, licenseType: LicenseType = 'free'): ValidationResult {
   // Check if file exists
@@ -65,7 +80,7 @@ export function validateFile(file: File, licenseType: LicenseType = 'free'): Val
 
   // Check size
   if (file.size === 0) {
-    return { valid: false, error: 'File is empty' };
+    return { valid: false, error: 'File is empty', reason: 'empty' };
   }
 
   // Check file size limit for the user's tier
@@ -77,11 +92,13 @@ export function validateFile(file: File, licenseType: LicenseType = 'free'): Val
       ? {
           valid: false,
           error: `檔案 ${sizeMB}MB 超過免費版 5MB 上限`,
+          reason: 'size_limit_free',
           upgradeAvailable: true,
         }
       : {
           valid: false,
           error: `檔案 ${sizeMB}MB 超過 ${isFreeTier ? '5' : '100'}MB 上限`,
+          reason: 'size_limit_pro',
         };
   }
 
@@ -93,6 +110,7 @@ export function validateFile(file: File, licenseType: LicenseType = 'free'): Val
     return {
       valid: false,
       error: 'Please upload text files only.',
+      reason: 'blocked_type',
     };
   }
 

--- a/types/gtm.d.ts
+++ b/types/gtm.d.ts
@@ -29,6 +29,18 @@ export interface FileConversionFailedEvent {
   input_encoding: string;
 }
 
+export interface FileRejectedEvent {
+  event: 'file_rejected';
+  file_size: number;
+  file_type: string;
+  /** Machine-readable rejection cause from the file validator */
+  reject_reason: 'size_limit_free' | 'size_limit_pro' | 'blocked_type' | 'empty';
+  /** True when a larger paid plan would have accepted the file */
+  upgrade_available: boolean;
+  /** Page path where the rejection happened (e.g. "/", "/srt") */
+  source_path: string;
+}
+
 export interface BeginCheckoutEvent {
   event: 'begin_checkout';
   currency: string;
@@ -49,6 +61,7 @@ export type DataLayerEvent =
   | FileConversionStartedEvent
   | FileConversionCompletedEvent
   | FileConversionFailedEvent
+  | FileRejectedEvent
   | BeginCheckoutEvent
   | UpgradeCtaClickedEvent;
 


### PR DESCRIPTION
## What

Adds a `file_rejected` GTM dataLayer event so the funnel's paywall moment — a guest hitting the free 5MB limit — becomes measurable in GA4 (property 367964438). Previously `FileUpload` rejected invalid files silently from an analytics standpoint.

## Changes

- **types/gtm.d.ts** — new `FileRejectedEvent` (`reject_reason`: `size_limit_free` | `size_limit_pro` | `blocked_type` | `empty`, `upgrade_available`, `source_path`), added to `DataLayerEvent` union
- **lib/file-validator.ts** — `ValidationResult` gains an optional machine-readable `reason` field, set in every rejection branch; user-facing behavior unchanged
- **lib/analytics.ts** — `trackFileRejected(file, reason, upgradeAvailable)` following the existing sanitize/source_path patterns (only file size + extension are sent, never the filename)
- **components/FileUpload.tsx** — fires the event in `onDrop` when validation fails, falling back to `blocked_type` if the validator returned no reason

## Verification

- `npx jest --ci`: **132/132** (12 suites; +2 new tests: FileUpload dataLayer assertion, validator reason on valid files)
- `npm run build`: green (Next 16 / Turbopack)
- `npm run lint`: 0 errors (2 pre-existing font warnings)
- `npx playwright test`: **8/8**, including the strengthened tiered-limits spec that now asserts the dataLayer contains exactly one `file_rejected` event with `reject_reason: 'size_limit_free'`, `upgrade_available: true`, `source_path: '/'` after the 9MB rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)