### PR TITLE
feat: new GTM container + Search Console verification meta

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,6 +44,9 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  verification: {
+    google: "kzkU9s6p6MuO60DdvtHqc57bVLIhw-LnjFvKMURJRJs",
+  },
 };
 
 export default function RootLayout({
@@ -65,7 +68,7 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <GoogleTagManager gtmId="GTM-TWV35322" />
+      <GoogleTagManager gtmId="GTM-5C6MXCL4" />
       <body className="font-sans text-slate-700 antialiased min-h-screen flex flex-col">
         {children}
       </body>


### PR DESCRIPTION
## What
- Swap GTM container to owner-controlled GTM-5C6MXCL4 (configured & published via Tag Manager API: Google Tag for G-0LMDG27L64 + GA4 event tag forwarding file_conversion_*, file_rejected, upgrade_cta_clicked, begin_checkout with parameter mapping)
- google-site-verification meta tag for Search Console onboarding

## Verification
- jest green, build green
- next start + curl: GTM-5C6MXCL4 and verification meta both served