### PR TITLE
feat: client-side EPUB 簡轉繁 conversion + /epub landing page

### DIFF
--- a/__tests__/components/FileUpload.test.tsx
+++ b/__tests__/components/FileUpload.test.tsx
@@ -10,6 +10,7 @@ jest.mock('@/lib/client-converter', () => ({
   areLibsLoaded: jest.fn(() => false),
   loadConverterLibs: jest.fn(),
   clearDictCache: jest.fn(),
+  isEpubFile: jest.fn((name: string) => name.toLowerCase().endsWith('.epub')),
 }));
 
 // Mock fetch for API calls (still needed for auth/profile)
@@ -43,7 +44,7 @@ describe('FileUpload Component', () => {
   it('should render upload dropzone with original text', () => {
     render(<FileUpload />);
 
-    expect(screen.getByText(/上傳檔案，支援 txt, csv, srt/i)).toBeInTheDocument();
+    expect(screen.getByText(/上傳檔案，支援 txt, epub, csv, srt/i)).toBeInTheDocument();
   });
 
   it('should accept file drop and auto-convert', async () => {

--- a/__tests__/lib/epub-converter.test.ts
+++ b/__tests__/lib/epub-converter.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the in-browser EPUB converter: builds a small EPUB fixture with
+ * fflate (mimetype + META-INF/container.xml + one .opf + two .xhtml with
+ * Simplified text + one fake binary image), converts it, and asserts the
+ * output is a valid EPUB whose mimetype entry is first and stored, whose
+ * text entries were converted, whose binary entry is byte-identical, and
+ * whose entry paths are preserved.
+ */
+import { zipSync, unzipSync, strToU8, strFromU8 } from 'fflate';
+import {
+  convertEpubBytes,
+  isEpubTextEntry,
+  EPUB_TEXT_EXTENSIONS,
+} from '@/lib/epub-converter';
+
+/**
+ * A minimal test converter mirroring the shape of the real pipeline: it
+ * only needs to demonstrate Simplified-to-Traditional substitution on the
+ * two sample words used in the fixture.
+ */
+function testConvert(text: string): string {
+  return text.replace(/软件/g, '軟體').replace(/网络/g, '網路');
+}
+
+/** Raw bytes standing in for a binary image entry (a fake 1x1 "PNG"). */
+const FAKE_IMAGE_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0xff, 0xfe]);
+
+const XHTML_1 =
+  '<?xml version="1.0" encoding="UTF-8"?>\n<html><body><p>软件测试</p></body></html>';
+const XHTML_2 =
+  '<?xml version="1.0" encoding="UTF-8"?>\n<html><body><p>网络世界</p></body></html>';
+const OPF =
+  '<?xml version="1.0" encoding="UTF-8"?>\n<package><metadata><title>软件网络</title></metadata></package>';
+const CONTAINER_XML =
+  '<?xml version="1.0"?>\n<container><rootfiles><rootfile full-path="OEBPS/content.opf"/></rootfiles></container>';
+
+/**
+ * Builds a minimal but structurally valid EPUB archive for testing. The
+ * mimetype entry is deliberately placed first and stored, matching a real
+ * EPUB produced by e-book tooling.
+ */
+function buildFixtureEpub(): Uint8Array {
+  return zipSync({
+    mimetype: [strToU8('application/epub+zip'), { level: 0 }],
+    'META-INF/container.xml': strToU8(CONTAINER_XML),
+    'OEBPS/content.opf': strToU8(OPF),
+    'OEBPS/chapter1.xhtml': strToU8(XHTML_1),
+    'OEBPS/chapter2.xhtml': strToU8(XHTML_2),
+    'OEBPS/images/cover.png': FAKE_IMAGE_BYTES,
+  });
+}
+
+/**
+ * Reads the first local file entry's name and compression method from a raw
+ * ZIP byte stream. Method 0 = stored, 8 = deflate. Used to assert the
+ * mimetype entry comes first and is uncompressed per the EPUB OCF spec.
+ */
+function readFirstEntry(zip: Uint8Array): { name: string; method: number } {
+  const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+  // Local file header: signature(4) version(2) flags(2) method(2) ...
+  const method = view.getUint16(8, true);
+  const nameLen = view.getUint16(26, true);
+  const nameBytes = zip.subarray(30, 30 + nameLen);
+  return { name: strFromU8(nameBytes), method };
+}
+
+describe('isEpubTextEntry', () => {
+  it.each(EPUB_TEXT_EXTENSIONS)('treats %s entries as convertible text', (ext) => {
+    expect(isEpubTextEntry(`OEBPS/file${ext}`)).toBe(true);
+  });
+
+  it('treats binary parts as non-text', () => {
+    expect(isEpubTextEntry('OEBPS/images/cover.png')).toBe(false);
+    expect(isEpubTextEntry('mimetype')).toBe(false);
+    expect(isEpubTextEntry('fonts/font.otf')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isEpubTextEntry('OEBPS/Chapter.XHTML')).toBe(true);
+  });
+});
+
+describe('convertEpubBytes', () => {
+  it('produces a valid zip whose mimetype entry is first and stored', () => {
+    const out = convertEpubBytes(buildFixtureEpub(), testConvert);
+
+    const first = readFirstEntry(out);
+    expect(first.name).toBe('mimetype');
+    expect(first.method).toBe(0); // stored, uncompressed
+
+    // Output unzips cleanly and the mimetype value is intact.
+    const entries = unzipSync(out);
+    expect(strFromU8(entries['mimetype'])).toBe('application/epub+zip');
+  });
+
+  it('converts Simplified text in xhtml and opf entries', () => {
+    const entries = unzipSync(convertEpubBytes(buildFixtureEpub(), testConvert));
+
+    expect(strFromU8(entries['OEBPS/chapter1.xhtml'])).toContain('軟體');
+    expect(strFromU8(entries['OEBPS/chapter1.xhtml'])).not.toContain('软件');
+    expect(strFromU8(entries['OEBPS/chapter2.xhtml'])).toContain('網路');
+    expect(strFromU8(entries['OEBPS/content.opf'])).toContain('軟體');
+    expect(strFromU8(entries['OEBPS/content.opf'])).toContain('網路');
+  });
+
+  it('passes binary entries through byte-for-byte', () => {
+    const entries = unzipSync(convertEpubBytes(buildFixtureEpub(), testConvert));
+    expect(Array.from(entries['OEBPS/images/cover.png'])).toEqual(
+      Array.from(FAKE_IMAGE_BYTES)
+    );
+  });
+
+  it('preserves every entry path', () => {
+    const original = Object.keys(unzipSync(buildFixtureEpub())).sort();
+    const converted = Object.keys(
+      unzipSync(convertEpubBytes(buildFixtureEpub(), testConvert))
+    ).sort();
+    expect(converted).toEqual(original);
+  });
+
+  it('reports per-entry conversion progress ending at 1', () => {
+    const fractions: number[] = [];
+    convertEpubBytes(buildFixtureEpub(), testConvert, {
+      onEntryProgress: (f) => fractions.push(f),
+    });
+    // Three text entries: content.opf, chapter1.xhtml, chapter2.xhtml.
+    expect(fractions.length).toBe(3);
+    expect(fractions[fractions.length - 1]).toBe(1);
+  });
+
+  it('synthesizes a mimetype entry when the source lacks one', () => {
+    const noMime = zipSync({
+      'OEBPS/content.opf': strToU8(OPF),
+    });
+    const out = convertEpubBytes(noMime, testConvert);
+    const first = readFirstEntry(out);
+    expect(first.name).toBe('mimetype');
+    expect(first.method).toBe(0);
+    expect(strFromU8(unzipSync(out)['mimetype'])).toBe('application/epub+zip');
+  });
+});

--- a/__tests__/lib/file-validator.test.ts
+++ b/__tests__/lib/file-validator.test.ts
@@ -89,4 +89,20 @@ describe('validateFile format blocking', () => {
     const result = validateFile(makeFile('subs.srt', 1024));
     expect(result.valid).toBe(true);
   });
+
+  it('accepts epub e-books (converted in-browser, no longer blocked)', () => {
+    const result = validateFile(makeFile('book.epub', 1024));
+    expect(result.valid).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it.each(['book.mobi', 'book.azw', 'book.azw3'])(
+    'rejects Kindle format %s with a Calibre-to-EPUB hint',
+    (name) => {
+      const result = validateFile(makeFile(name, 1024));
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('blocked_type');
+      expect(result.error).toContain('Calibre');
+    }
+  );
 });

--- a/app/epub/page.tsx
+++ b/app/epub/page.tsx
@@ -1,0 +1,165 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import FileUpload from '@/components/FileUpload';
+import Footer from '@/components/Footer';
+import Header from '@/components/Header';
+import { getAuthUser, getProfile } from '@/lib/actions/auth';
+
+/**
+ * SEO landing page for EPUB e-book conversion queries (epub 簡轉繁,
+ * 電子書簡體轉繁體, 簡體小說 epub 轉台灣繁體). Hosts the same in-browser
+ * converter as the homepage with e-book-specific guidance, and emphasizes
+ * the no-upload architecture and the Pro custom dictionary (fixing novel
+ * character names across a whole book) as the paid differentiator.
+ */
+
+export const metadata: Metadata = {
+  title: 'EPUB 電子書簡轉繁 — 免上傳、瀏覽器內轉繁體中文',
+  description:
+    '簡體 EPUB 電子書免費線上轉繁體中文：拖曳上傳即在瀏覽器內完成，檔案不上傳伺服器，排版與圖片不變，只轉文字。搭配自訂字典可固定小說人名的譯法，整本書統一。',
+  alternates: { canonical: '/epub' },
+  openGraph: {
+    title: 'EPUB 電子書簡轉繁 — 免上傳、瀏覽器內轉繁體中文',
+    description:
+      '簡體 EPUB 電子書免費線上轉繁體中文，檔案不上傳伺服器，只轉文字不動排版；自訂字典可固定小說人名譯法。',
+    url: 'https://txtconv.arpuli.com/epub',
+  },
+};
+
+const EPUB_FAQ = [
+  {
+    question: '我的電子書會被上傳到伺服器嗎？',
+    answer:
+      '不會。txtconv 的轉換完全在你的瀏覽器內完成：EPUB 會在本機解壓縮、逐一轉換內文、再重新打包成新的 EPUB，整個過程檔案都不會離開你的裝置，也不會被儲存副本。多數線上電子書轉換工具都要求把整本書上傳到伺服器，我們刻意不這麼做。',
+  },
+  {
+    question: '支援 mobi、azw、azw3（Kindle）格式嗎？',
+    answer:
+      '目前只支援 EPUB。mobi/azw/azw3 是 Kindle 的專屬格式，無法在瀏覽器內直接開啟。你可以先用免費軟體 Calibre 把書轉成 EPUB，再上傳到本頁轉換即可。',
+  },
+  {
+    question: '轉完排版會亂掉嗎？',
+    answer:
+      '不會。txtconv 只轉換 EPUB 內的文字內容（章節 XHTML、目錄、書名等），圖片、字型、CSS 樣式與檔案結構全部原封不動保留，因此排版、封面與插圖都跟原書一樣，只有簡體字被轉成台灣正體。',
+  },
+  {
+    question: '小說裡的人名、專有名詞可以固定譯法嗎？',
+    answer:
+      '可以，這是 Pro 版的重點。OpenCC 的通用詞庫有時會把同一個名字轉成不同寫法，或轉成你不想要的譯名。登入 Pro 後可自訂字典，指定「簡體詞 → 你要的繁體寫法」，整本書的人名、地名、專有名詞都會統一，不必逐章手動改。',
+  },
+  {
+    question: '免費版有什麼限制？',
+    answer:
+      '免費版可轉換 5MB 以內的檔案，適合多數純文字小說 EPUB。較大的電子書（含大量插圖）常會超過 5MB，升級 Pro 後上限提高到 100MB，同時解鎖可存 10,000 組對照的自訂字典。',
+  },
+];
+
+export default async function EpubLandingPage() {
+  const user = await getAuthUser();
+  const profile = user ? await getProfile(user.id) : null;
+
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: EPUB_FAQ.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: { '@type': 'Answer', text: item.answer },
+    })),
+  };
+
+  return (
+    <>
+      <Header user={user} profile={profile} />
+
+      <main className="flex-1 max-w-5xl mx-auto w-full px-6 py-12 flex flex-col gap-12">
+        <section className="space-y-6">
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-800 leading-snug">
+            EPUB 電子書簡轉繁：免上傳，瀏覽器內轉台灣繁體
+          </h1>
+          <p className="text-lg text-gray-600 max-w-4xl">
+            買到或下載到的簡體 EPUB 小說，看起來總是不習慣？把 .epub
+            檔拖進下方轉換區，txtconv 直接在你的瀏覽器內把整本書轉成台灣正體中文
+            —— 檔案不上傳伺服器、只轉文字不動排版與圖片，轉完就是一本可以正常閱讀的繁體
+            EPUB。搭配 Pro 自訂字典，還能固定小說人名與專有名詞的譯法，整本書統一。
+          </p>
+        </section>
+
+        <FileUpload licenseType={profile?.license_type ?? 'free'} />
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold text-gray-800">三步驟轉換電子書</h2>
+          <ol className="list-decimal pl-6 space-y-2 text-gray-600">
+            <li>準備簡體 EPUB 檔（Kindle 的 mobi/azw 請先用 Calibre 轉成 EPUB）</li>
+            <li>拖曳（或點選）上傳到本頁的轉換區，會在瀏覽器內自動開始轉換</li>
+            <li>點下載取得繁體 EPUB，直接匯入閱讀器或 App 就能閱讀</li>
+          </ol>
+          <p className="text-gray-600">
+            也需要轉換純文字小說或字幕？請見{' '}
+            <a href="/novel" className="text-primary hover:underline">
+              小說 TXT 簡轉繁
+            </a>
+            、
+            <a href="/dictionary-guide" className="text-primary hover:underline">
+              自訂字典使用說明
+            </a>
+            ，或回到
+            <Link href="/" className="text-primary hover:underline">
+              首頁
+            </Link>
+            查看完整功能與方案。
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold text-gray-800">為什麼選 txtconv 轉電子書</h2>
+          <ul className="list-disc pl-6 space-y-2 text-gray-600">
+            <li>
+              <span className="font-medium text-gray-800">免上傳、更隱私：</span>
+              轉換在瀏覽器內完成，整本書不會離開你的電腦，也不會被存到任何伺服器。
+            </li>
+            <li>
+              <span className="font-medium text-gray-800">只動文字、不毀排版：</span>
+              圖片、封面、字型與樣式原樣保留，轉完的 EPUB 版面跟原書一致。
+            </li>
+            <li>
+              <span className="font-medium text-gray-800">台灣用語詞庫：</span>
+              使用 OpenCC 台灣正體詞庫，把「软件、视频、信息」轉成「軟體、影片、資訊」。
+            </li>
+            <li>
+              <span className="font-medium text-gray-800">Pro 自訂字典固定譯名：</span>
+              整本書的人名、地名、專有名詞統一寫法，不必逐章手動修改。
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold text-gray-800">電子書轉換常見問題</h2>
+          <div className="space-y-4">
+            {EPUB_FAQ.map((item) => (
+              <details
+                key={item.question}
+                className="group bg-white rounded-2xl shadow-sm border border-gray-100 px-6 py-4"
+              >
+                <summary className="cursor-pointer list-none flex items-center justify-between gap-4 font-medium text-gray-800">
+                  <h3 className="text-base font-medium">{item.question}</h3>
+                  <span className="material-symbols-outlined text-gray-400 transition-transform group-open:rotate-180">
+                    expand_more
+                  </span>
+                </summary>
+                <p className="mt-3 text-sm leading-relaxed text-gray-600">{item.answer}</p>
+              </details>
+            ))}
+          </div>
+        </section>
+
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        />
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -63,6 +63,11 @@ export default async function Home() {
               </a>
             </p>
             <p>
+              <a href="/epub" className="hover:text-primary underline underline-offset-2">
+                .epub 電子書檔案
+              </a>
+            </p>
+            <p>
               <a href="/srt" className="hover:text-primary underline underline-offset-2">
                 .srt 電影字幕檔案
               </a>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -15,6 +15,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
     },
     {
+      url: `${base}/epub`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
       url: `${base}/srt`,
       changeFrequency: 'monthly',
       priority: 0.8,

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -5,6 +5,7 @@ import { useDropzone } from 'react-dropzone';
 import { validateFile } from '@/lib/file-validator';
 import {
   convertFile as clientConvertFile,
+  isEpubFile,
   type ConversionProgress,
 } from '@/lib/client-converter';
 import {
@@ -30,9 +31,32 @@ export interface UploadFile {
   errMessage: string | null;
   isRetryable: boolean;  // true = server error, false = validation error
   upgradeAvailable?: boolean;  // rejected only by the free-tier size limit; show upgrade CTA
-  convertedContent?: string;
+  convertedBlob?: Blob;  // finished output, ready to download (text or binary, e.g. EPUB)
   conversionStartTime?: number;
   inputEncoding?: string;
+  progressLabel?: string;  // stage-specific progress copy (Traditional Chinese), used for EPUB
+}
+
+/**
+ * Maps a conversion stage to Traditional Chinese progress copy for EPUB
+ * e-books. Non-EPUB files keep the generic English status, so this returns
+ * undefined for stages that only apply to plain-text conversion.
+ */
+function epubProgressLabel(stage: ConversionProgress['stage']): string | undefined {
+  switch (stage) {
+    case 'loading-libs':
+      return '載入轉換引擎中…';
+    case 'loading-dict':
+      return '載入自訂字典中…';
+    case 'epub-unzip':
+      return '解壓縮電子書中…';
+    case 'converting':
+      return '轉換章節中…';
+    case 'epub-rezip':
+      return '重新打包電子書中…';
+    default:
+      return undefined;
+  }
 }
 
 // Circular progress ring component
@@ -118,7 +142,9 @@ function FileRow({
     dotColor = 'bg-blue-400';
     dotAnimate = true;
   } else if (isConverting) {
-    statusText = 'Converting...';
+    // EPUB conversion surfaces Traditional Chinese stage copy; other files
+    // keep the generic English status.
+    statusText = store.progressLabel || 'Converting...';
     dotColor = 'bg-amber-400';
     dotAnimate = true;
   } else if (isWaiting) {
@@ -206,7 +232,7 @@ function FileRow({
 
 export default function FileUpload({ licenseType = 'free' }: { licenseType?: LicenseType }) {
   const [files, setFiles] = useState<UploadFile[]>([]);
-  const [downloadQueue, setDownloadQueue] = useState<Array<{ content: string; fileName: string }>>([]);
+  const [downloadQueue, setDownloadQueue] = useState<Array<{ blob: Blob; fileName: string }>>([]);
   const isProcessingQueue = useRef(false);
   const [userId, setUserId] = useState<string | undefined>(undefined);
 
@@ -222,10 +248,10 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
   useEffect(() => {
     if (downloadQueue.length > 0 && !isProcessingQueue.current) {
       isProcessingQueue.current = true;
-      const { content, fileName } = downloadQueue[0];
+      const { blob, fileName } = downloadQueue[0];
 
-      // Download the file
-      const blob = new Blob([content], { type: 'text/plain; charset=utf-8' });
+      // Download the file (Blob already carries the correct MIME type —
+      // text/plain for text files, application/epub+zip for e-books).
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
@@ -266,7 +292,8 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
       )
     );
 
-    let convertedContent: string;
+    const isEpub = isEpubFile(file.name);
+    let convertedBlob: Blob;
     let convertedFileName: string;
     let inputEncoding: string;
 
@@ -274,6 +301,8 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
       // Run client-side conversion with progress
       const result = await clientConvertFile(file, userId, (progress: ConversionProgress) => {
         const displayPercent = progress.percent;
+        // EPUB shows Traditional Chinese stage copy; other files stay generic.
+        const progressLabel = isEpub ? epubProgressLabel(progress.stage) : undefined;
 
         // Map stages to progress ranges for UI
         // loading-libs: 0-10%, loading-dict: 10-15%, converting: 15-100%
@@ -283,13 +312,21 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
               ? {
                   ...f,
                   convertProgress: displayPercent,
+                  progressLabel: progressLabel ?? f.progressLabel,
                 }
               : f
           )
         );
       });
 
-      convertedContent = result.content;
+      // Binary formats (EPUB) carry `bytes`; text formats carry `content`.
+      // Copy the bytes into a fresh Uint8Array so the Blob owns a plain
+      // ArrayBuffer (satisfies the BlobPart type across TS lib versions).
+      convertedBlob = result.bytes
+        ? new Blob([new Uint8Array(result.bytes)], {
+            type: result.mimeType || 'application/octet-stream',
+          })
+        : new Blob([result.content], { type: 'text/plain; charset=utf-8' });
       convertedFileName = result.fileName;
       inputEncoding = result.encoding;
     } catch (error) {
@@ -326,7 +363,7 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
               convertProgress: 1.0,
               downloadLink: 'blob://converted',
               filename: convertedFileName,
-              convertedContent: convertedContent,
+              convertedBlob,
               inputEncoding,
             }
           : f
@@ -334,7 +371,7 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
     );
 
     // Add to download queue
-    setDownloadQueue((prev) => [...prev, { content: convertedContent, fileName: convertedFileName }]);
+    setDownloadQueue((prev) => [...prev, { blob: convertedBlob, fileName: convertedFileName }]);
   }, [userId]);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
@@ -415,9 +452,8 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
   // Download handler
   const downloadFile = useCallback((fileId: string) => {
     const file = files.find((f) => f.id === fileId);
-    if (file?.convertedContent && file?.filename) {
-      const blob = new Blob([file.convertedContent], { type: 'text/plain; charset=utf-8' });
-      const url = URL.createObjectURL(blob);
+    if (file?.convertedBlob && file?.filename) {
+      const url = URL.createObjectURL(file.convertedBlob);
       const a = document.createElement('a');
       a.href = url;
       a.download = file.filename;
@@ -441,7 +477,7 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
           >
             <input {...getInputProps()} />
             <p className="text-2xl font-medium text-primary text-center pointer-events-none">
-              上傳檔案，支援 txt, csv, srt, ...
+              上傳檔案，支援 txt, epub, csv, srt, ...
             </p>
           </div>
         </div>

--- a/e2e/epub.spec.ts
+++ b/e2e/epub.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * End-to-end checks for EPUB conversion: a real (in-test generated) .epub
+ * dropped on the homepage uploader converts in-browser and produces an
+ * .epub download whose text was converted Simplified->Traditional; and the
+ * /epub landing page renders with its H1 and FAQ JSON-LD marker.
+ */
+import { test, expect } from '@playwright/test';
+import { zipSync, unzipSync, strToU8, strFromU8 } from 'fflate';
+
+/**
+ * Builds a minimal valid EPUB (mimetype first + container + opf + one
+ * chapter with Simplified text) as a Buffer for upload.
+ */
+function buildEpubBuffer(): Buffer {
+  const zipped = zipSync({
+    mimetype: [strToU8('application/epub+zip'), { level: 0 }],
+    'META-INF/container.xml': strToU8(
+      '<?xml version="1.0"?>\n<container><rootfiles><rootfile full-path="OEBPS/content.opf"/></rootfiles></container>'
+    ),
+    'OEBPS/content.opf': strToU8(
+      '<?xml version="1.0" encoding="UTF-8"?>\n<package><metadata><title>软件</title></metadata></package>'
+    ),
+    'OEBPS/chapter1.xhtml': strToU8(
+      '<?xml version="1.0" encoding="UTF-8"?>\n<html><body><p>软件测试网络世界</p></body></html>'
+    ),
+  });
+  return Buffer.from(zipped);
+}
+
+test('epub dropped on homepage converts and downloads as .epub', async ({ page }) => {
+  await page.goto('/');
+
+  const downloadPromise = page.waitForEvent('download');
+
+  await page.setInputFiles('input[type="file"]', {
+    name: 'test-book.epub',
+    mimeType: 'application/epub+zip',
+    buffer: buildEpubBuffer(),
+  });
+
+  await expect(page.getByText('Finished')).toBeVisible({ timeout: 30000 });
+
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/\.epub$/);
+
+  // The downloaded EPUB must still be a valid zip whose chapter text was
+  // converted to Traditional Chinese.
+  const stream = await download.createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(chunk as Buffer);
+  const entries = unzipSync(new Uint8Array(Buffer.concat(chunks)));
+
+  expect(Object.keys(entries)).toContain('OEBPS/chapter1.xhtml');
+  const chapter = strFromU8(entries['OEBPS/chapter1.xhtml']);
+  expect(chapter).toContain('軟體');
+  expect(chapter).toContain('網路');
+  expect(chapter).not.toContain('软件');
+});
+
+test('/epub landing page renders with H1 and FAQ JSON-LD', async ({ page }) => {
+  const response = await page.goto('/epub');
+  expect(response?.status()).toBe(200);
+
+  await expect(
+    page.getByRole('heading', { level: 1, name: /EPUB 電子書簡轉繁/ })
+  ).toBeVisible();
+
+  // FAQPage structured data must be present for rich-result eligibility.
+  const jsonLd = await page
+    .locator('script[type="application/ld+json"]')
+    .innerText();
+  expect(jsonLd).toContain('FAQPage');
+
+  // Converter is embedded on the landing page too.
+  await expect(page.locator('input[type="file"]')).toBeAttached();
+});

--- a/lib/client-converter.ts
+++ b/lib/client-converter.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { applyCustomDict, parseDictionary, type DictPair } from '@/lib/custom-dict';
+import { convertEpubBytes, EPUB_MIME_TYPE } from '@/lib/epub-converter';
 import { createClient } from '@/lib/supabase/client';
 import { TEST_USER_ID, TEST_CUSTOM_DICT_PAIRS } from '@/lib/test-user';
 
@@ -36,7 +37,15 @@ function getTestSession(): { userId: string } | null {
   return null;
 }
 
-export type ConversionStage = 'loading-libs' | 'loading-dict' | 'converting' | 'complete';
+export type ConversionStage =
+  | 'loading-libs'
+  | 'loading-dict'
+  | 'converting'
+  | 'complete'
+  // EPUB-specific stages: unzipping the e-book and re-packing it after
+  // conversion. Used by the UI to show e-book-specific progress copy.
+  | 'epub-unzip'
+  | 'epub-rezip';
 
 export interface ConversionProgress {
   stage: ConversionStage;
@@ -48,9 +57,26 @@ export interface ConversionProgress {
 export type ProgressCallback = (progress: ConversionProgress) => void;
 
 export interface ConversionResult {
+  /** Converted text output; empty string for binary formats (see `bytes`). */
   content: string;
+  /**
+   * Converted binary output, present for archive formats such as EPUB. When
+   * set, the caller downloads these bytes (using `mimeType`) instead of
+   * `content`.
+   */
+  bytes?: Uint8Array;
+  /** MIME type for the download Blob; only set alongside `bytes`. */
+  mimeType?: string;
   fileName: string;
   encoding: string;
+}
+
+/**
+ * Returns true when the filename is an EPUB e-book, which is converted
+ * through the archive pipeline rather than the plain-text pipeline.
+ */
+export function isEpubFile(name: string): boolean {
+  return name.toLowerCase().endsWith('.epub');
 }
 
 /**
@@ -375,6 +401,70 @@ export function generateConvertedFilename(originalName: string): string {
 }
 
 /**
+ * Builds a single text-conversion function that applies the user's custom
+ * dictionary (if any) on top of the OpenCC converter. Shared by the plain-
+ * text and EPUB pipelines so both honor Pro custom dictionaries identically.
+ *
+ * @param customPairs - The user's custom dictionary pairs (may be empty)
+ * @returns A `(text) => text` converter
+ */
+function buildConverter(customPairs: DictPair[]): (text: string) => string {
+  if (!converterInstance) {
+    throw new Error('Converter not loaded. Call loadConverterLibs first.');
+  }
+  const converter = converterInstance;
+  return (text: string) =>
+    customPairs.length > 0 ? applyCustomDict(text, customPairs, converter) : converter(text);
+}
+
+/**
+ * Converts an EPUB e-book entirely in the browser: its bytes are unzipped,
+ * text entries are run through the shared conversion pipeline (OpenCC +
+ * custom dictionary), and the archive is re-zipped with the same layout.
+ * The book never leaves the device.
+ *
+ * @param file - The .epub File to convert
+ * @param customPairs - The user's custom dictionary pairs (may be empty)
+ * @param onProgress - Progress callback; emits EPUB-specific stages
+ * @returns Conversion result carrying the new EPUB bytes and a converted
+ *   filename
+ */
+async function convertEpubFile(
+  file: File,
+  customPairs: DictPair[],
+  onProgress: ProgressCallback
+): Promise<ConversionResult> {
+  const convert = buildConverter(customPairs);
+
+  // Stage 3: Read the whole file as bytes (no text-encoding detection —
+  // EPUB mandates UTF-8 for its text entries).
+  onProgress({ stage: 'epub-unzip', percent: 0.15 });
+  const input = new Uint8Array(await file.arrayBuffer());
+
+  // Yield once so the "unzipping" progress paints before the synchronous
+  // unzip/convert/zip work runs.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // Stage 4: Convert text entries (15-90%).
+  const bytes = convertEpubBytes(input, convert, {
+    onEntryProgress: (fraction) => {
+      onProgress({ stage: 'converting', percent: 0.15 + fraction * 0.75 });
+    },
+  });
+
+  // Stage 5: Re-packed.
+  onProgress({ stage: 'epub-rezip', percent: 0.95 });
+
+  return {
+    content: '',
+    bytes,
+    mimeType: EPUB_MIME_TYPE,
+    fileName: generateConvertedFilename(file.name),
+    encoding: 'UTF-8',
+  };
+}
+
+/**
  * Full conversion pipeline for a single file
  */
 export async function convertFile(
@@ -392,6 +482,11 @@ export async function convertFile(
   onProgress({ stage: 'loading-dict', percent: 0.1 });
   const customPairs = await loadUserDictionary(userId);
   onProgress({ stage: 'loading-dict', percent: 0.15 });
+
+  // EPUB e-books take the archive pipeline (binary in, binary out).
+  if (isEpubFile(file.name)) {
+    return convertEpubFile(file, customPairs, onProgress);
+  }
 
   // Stage 3: Read file and detect encoding
   onProgress({ stage: 'converting', percent: 0.15 });

--- a/lib/epub-converter.ts
+++ b/lib/epub-converter.ts
@@ -1,0 +1,126 @@
+/**
+ * In-browser EPUB (.epub) Simplified-to-Traditional conversion.
+ *
+ * An EPUB is a ZIP archive (an OCF container). This module unzips it with
+ * fflate, runs a caller-supplied text-conversion function on the
+ * human-readable text entries (content documents, package metadata, and
+ * legacy navigation), and re-zips while preserving every other entry
+ * (images, fonts, CSS, binary parts) byte-for-byte. The archive is rebuilt
+ * with the `mimetype` entry first and stored (uncompressed) as required by
+ * the EPUB OCF specification, so the output stays a valid, readable EPUB
+ * with only its text converted.
+ *
+ * The module is intentionally free of any OpenCC / custom-dictionary
+ * coupling: it receives the conversion as a plain `(text) => text` callback
+ * so it can reuse the existing pipeline in lib/client-converter.ts and stay
+ * unit-testable without loading the converter. Everything runs on the
+ * user's device; the book is never uploaded.
+ */
+
+import { unzipSync, zipSync, strToU8, strFromU8, type Zippable } from 'fflate';
+
+/**
+ * File extensions whose entries hold convertible UTF-8 text: EPUB content
+ * documents (.xhtml/.html/.htm), the package document (.opf), the legacy
+ * NCX navigation (.ncx), and any plain-text parts (.txt). The EPUB spec
+ * mandates UTF-8 for these, so no encoding detection is needed.
+ */
+export const EPUB_TEXT_EXTENSIONS = ['.xhtml', '.html', '.htm', '.opf', '.ncx', '.txt'] as const;
+
+/**
+ * The MIME type an EPUB's reserved `mimetype` entry must contain, and the
+ * type used for the converted download Blob.
+ */
+export const EPUB_MIME_TYPE = 'application/epub+zip';
+
+/**
+ * Determines whether an archive entry holds convertible UTF-8 text.
+ *
+ * @param path - Entry path inside the EPUB (e.g. "OEBPS/chapter1.xhtml")
+ * @returns True when the entry is a text document that should be converted;
+ *   false for images, fonts, CSS, and other binary parts that pass through
+ *   unchanged
+ */
+export function isEpubTextEntry(path: string): boolean {
+  const lower = path.toLowerCase();
+  return EPUB_TEXT_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+/** Options for {@link convertEpubBytes}. */
+export interface EpubConvertOptions {
+  /**
+   * Reports progress of the per-entry text conversion as a fraction in the
+   * range 0..1 (called once per converted text entry). Binary passthrough
+   * entries do not advance this fraction.
+   */
+  onEntryProgress?: (fraction: number) => void;
+}
+
+/**
+ * Converts the text content of an EPUB archive from Simplified to
+ * Traditional Chinese, returning a new, valid EPUB archive.
+ *
+ * Text entries (see {@link EPUB_TEXT_EXTENSIONS}) are decoded as UTF-8, run
+ * through `convert`, and re-encoded as UTF-8. Every other entry is copied
+ * byte-for-byte. The rebuilt archive places the `mimetype` entry first and
+ * stores it uncompressed (compression level 0) per the EPUB OCF spec; all
+ * original entry paths are preserved.
+ *
+ * @param input - Raw bytes of the source .epub file
+ * @param convert - Text conversion function; receives decoded UTF-8 text of
+ *   one entry and returns the converted text. Reuse the existing OpenCC +
+ *   custom-dictionary pipeline here.
+ * @param options - Optional progress reporting; see {@link EpubConvertOptions}
+ * @returns Bytes of a new, valid EPUB with only its text converted
+ * @example
+ *   const out = convertEpubBytes(epubBytes, (t) => converter(t));
+ */
+export function convertEpubBytes(
+  input: Uint8Array,
+  convert: (text: string) => string,
+  options: EpubConvertOptions = {}
+): Uint8Array {
+  const entries = unzipSync(input);
+  const paths = Object.keys(entries);
+
+  const rebuilt: Zippable = {};
+
+  // The `mimetype` entry must come first and be stored (uncompressed). Pass
+  // through the original value when present; otherwise synthesize the
+  // spec-required value so the output is still a valid EPUB.
+  const mimetypeValue = entries['mimetype']
+    ? strFromU8(entries['mimetype'])
+    : EPUB_MIME_TYPE;
+  rebuilt['mimetype'] = [strToU8(mimetypeValue), { level: 0 }];
+
+  // Count text entries up front so progress reports a stable denominator.
+  const textEntryCount = paths.filter(
+    (p) => p !== 'mimetype' && isEpubTextEntry(p)
+  ).length;
+
+  let convertedCount = 0;
+  for (const path of paths) {
+    // `mimetype` was already placed first above.
+    if (path === 'mimetype') continue;
+
+    const bytes = entries[path];
+    if (isEpubTextEntry(path)) {
+      // strFromU8 decodes as UTF-8 by default, matching the EPUB spec.
+      const converted = convert(strFromU8(bytes));
+      rebuilt[path] = strToU8(converted);
+      convertedCount++;
+      options.onEntryProgress?.(
+        textEntryCount === 0 ? 1 : convertedCount / textEntryCount
+      );
+    } else {
+      // Binary parts (images, fonts, CSS, cover, etc.) pass through unchanged.
+      rebuilt[path] = bytes;
+    }
+  }
+
+  if (textEntryCount === 0) {
+    options.onEntryProgress?.(1);
+  }
+
+  return zipSync(rebuilt);
+}

--- a/lib/file-validator.ts
+++ b/lib/file-validator.ts
@@ -22,15 +22,21 @@ export function getMaxFileSize(licenseType: LicenseType = 'free'): number {
     : FREE_MAX_FILE_SIZE;
 }
 
-// Block common video and office file extensions
+// Kindle e-book formats we cannot open in the browser. They are proprietary
+// (not ZIP-based like EPUB), so we reject them with guidance to convert to
+// EPUB first rather than a generic "text files only" message.
+export const KINDLE_EXTENSIONS = ['.mobi', '.azw', '.azw3'];
+
+// Block common video, office and non-EPUB binary file extensions. EPUB is
+// intentionally NOT blocked: it is a ZIP of UTF-8 text that we convert
+// in-browser (see lib/epub-converter.ts). Kindle formats are handled
+// separately via KINDLE_EXTENSIONS so they get a Calibre-conversion hint.
 export const BLOCKED_EXTENSIONS = [
   // Video files
   '.mov', '.mp4', '.avi', '.mkv', '.wmv', '.flv', '.webm', '.m4v',
   // Office files
   '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.pdf',
   '.pages', '.numbers', '.key', // Mac iWork
-  // Ebook files
-  '.epub', '.mobi', '.azw', '.azw3',
   // Other binary files
   '.exe', '.zip', '.rar', '.7z', '.tar', '.gz',
   '.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.svg',
@@ -102,8 +108,21 @@ export function validateFile(file: File, licenseType: LicenseType = 'free'): Val
         };
   }
 
-  // Block video and office files
+  // Kindle e-book formats: not openable in-browser. Reuse the blocked_type
+  // reason (keeps the analytics union stable) but with a message telling the
+  // user to convert to EPUB with Calibre first, since EPUB IS supported.
   const fileName = file.name.toLowerCase();
+  const isKindle = KINDLE_EXTENSIONS.some((ext) => fileName.endsWith(ext));
+
+  if (isKindle) {
+    return {
+      valid: false,
+      error: '暫不支援 mobi/azw 格式，請先用 Calibre 轉成 EPUB 再上傳。',
+      reason: 'blocked_type',
+    };
+  }
+
+  // Block video, office and other binary files.
   const isBlocked = BLOCKED_EXTENSIONS.some((ext) => fileName.endsWith(ext));
 
   if (isBlocked) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/supabase-js": "^2.90.0",
         "@vercel/blob": "^2.0.1",
         "encoding-japanese": "^2.2.0",
+        "fflate": "^0.8.3",
         "next": "^16.2.10",
         "opencc-js": "^1.0.5",
         "react": "^19.2.7",
@@ -5660,6 +5661,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@supabase/supabase-js": "^2.90.0",
     "@vercel/blob": "^2.0.1",
     "encoding-japanese": "^2.2.0",
+    "fflate": "^0.8.3",
     "next": "^16.2.10",
     "opencc-js": "^1.0.5",
     "react": "^19.2.7",


### PR DESCRIPTION
## Why
Paid-user survey (2026-07-05): 3/7 payers are novel/ebook readers and EPUB was explicitly requested. Every competing EPUB converter uploads the whole book to a server — our client-side/no-upload conversion is the moat, and the Pro custom dictionary (fixing novel character names across a whole book) is the paid differentiator.

## What shipped
- **`lib/epub-converter.ts`** (new): unzip EPUB with `fflate`, convert text entries (`.xhtml/.html/.htm/.opf/.ncx/.txt`) decoded as UTF-8 through a caller-supplied converter, re-zip with `mimetype` first + stored (level 0) per the EPUB OCF spec; all other entries (images/fonts/css) pass through byte-identical, entry paths preserved. Pure and unit-testable (no OpenCC coupling).
- **`lib/client-converter.ts`**: `.epub` routes through the archive pipeline (binary in/out), reusing the existing OpenCC `s2twp` + custom-dictionary pipeline. Filename converted like other files (书名.epub → 書名.epub).
- **`lib/file-validator.ts`**: `.epub` unblocked (validates like other files; free 5MB paywall unchanged). `.mobi/.azw/.azw3` stay blocked with a dedicated message: 「暫不支援 mobi/azw 格式，請先用 Calibre 轉成 EPUB 再上傳。」 (reuses `blocked_type` reason to keep the analytics union stable).
- **`components/FileUpload.tsx`**: binary download support (Blob with `application/epub+zip`), Traditional Chinese EPUB progress copy (解壓縮電子書中 / 轉換章節中 / 重新打包電子書中). `file_conversion_started/completed/failed` fire for `.epub` (file_type `.epub`) as before.
- **`app/epub/page.tsx`** (new): SEO landing page — metadata + canonical `/epub`, H1 「EPUB 電子書簡轉繁」, positioning 免上傳/瀏覽器內完成/Pro 自訂字典固定小說人名, FAQ + FAQPage JSON-LD (檔案會上傳嗎→不會 / mobi-azw→Calibre / 排版會亂嗎→只轉文字 / 免費限制→5MB, Pro 100MB), cross-links to `/` `/novel` `/dictionary-guide`; added to `app/sitemap.ts` and linked from the homepage format list.
- **`fflate`** dependency (zero-dep browser zip/unzip; `npm audit` 0 vulns).

## Verification
- `npx jest --ci`: **150/150 passed** (13 suites). New: `__tests__/lib/epub-converter.test.ts` (builds an in-test fixture EPUB — mimetype + container.xml + .opf + two .xhtml with 软件测试/网络 + a fake binary image — and asserts output mimetype is first & stored, xhtml/opf contain 軟體/網路, binary byte-identical, paths preserved, progress ends at 1) + validator tests (epub accepted, mobi/azw/azw3 rejected with Calibre hint).
- `npm run lint`: **0 errors** (2 pre-existing font warnings).
- `npm run build`: **green**, `/epub` route present.
- **Playwright e2e: 10/10 passed** (`e2e/epub.spec.ts` new: generates a real .epub, drops it on the homepage, waits for Finished, captures the download, asserts `.epub` filename AND unzips the downloaded bytes to confirm chapter text became 軟體/網路; plus /epub renders 200 + H1 + FAQPage marker).
- Live dev-server curl: `/epub` 200 + FAQPage, sitemap contains `/epub`, homepage links `/epub`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)