### PR TITLE
feat: add /jianying landing page for 剪映/CapCut subtitle 簡轉繁 queries

### DIFF
--- a/app/jianying/page.tsx
+++ b/app/jianying/page.tsx
@@ -1,0 +1,194 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import FileUpload from '@/components/FileUpload';
+import Footer from '@/components/Footer';
+import Header from '@/components/Header';
+import { getAuthUser, getProfile } from '@/lib/actions/auth';
+
+/**
+ * SEO landing page for the 剪映/CapCut subtitle query family (剪映字幕簡轉繁,
+ * CapCut 字幕簡體轉繁體, 剪映 SRT 繁體). 剪映 auto-generates Simplified
+ * subtitles via speech recognition and Taiwanese users want Traditional; this
+ * page targets those searches by name, documents the honest export-then-convert
+ * workflow, and embeds the same in-browser converter as the homepage so users
+ * can convert their exported .srt immediately.
+ */
+
+export const metadata: Metadata = {
+  title: '剪映字幕簡轉繁｜CapCut 字幕簡體轉繁體（SRT 一鍵轉換）',
+  description:
+    '剪映（CapCut）自動辨識的字幕是簡體中文？把匯出的 .srt 字幕檔拖進本頁，免費在瀏覽器內一鍵轉成台灣繁體：時間軸不變、自動轉台灣用語（软件→軟體、视频→影片），檔案不上傳伺服器，轉完可重新匯回剪映。',
+  keywords: [
+    '剪映字幕繁體',
+    '剪映字幕簡轉繁',
+    'CapCut 簡轉繁',
+    'CapCut 字幕簡體轉繁體',
+    '剪映 SRT 繁體',
+    '剪映字幕轉台灣繁體',
+    '剪映字幕轉繁體',
+  ],
+  alternates: { canonical: '/jianying' },
+  openGraph: {
+    title: '剪映字幕簡轉繁｜CapCut 字幕簡體轉繁體（SRT 一鍵轉換）',
+    description:
+      '剪映（CapCut）匯出的簡體 .srt 字幕免費線上轉台灣繁體：時間軸不變、自動轉台灣用語，檔案不上傳伺服器，轉完可重新匯回剪映。',
+    url: 'https://txtconv.arpuli.com/jianying',
+  },
+};
+
+const JIANYING_FAQ = [
+  {
+    question: '剪映匯出的字幕是簡體，怎麼轉成繁體？',
+    answer:
+      '剪映（CapCut）的 AI 語音辨識預設產生簡體中文字幕。先在剪映把字幕匯出成 .srt 檔，再把檔案拖進本頁的轉換區，txtconv 會在你的瀏覽器內用 OpenCC 台灣正體詞庫把「软件、视频、信息」轉成「軟體、影片、資訊」，時間軸與序號完全不動，轉完就是一份台灣繁體字幕。',
+  },
+  {
+    question: '檔案會上傳到伺服器嗎？',
+    answer:
+      '不會。txtconv 的轉換完全在你的瀏覽器內完成，字幕檔不會離開你的裝置，也不會被儲存任何副本。這也代表就算是尚未公開的影片字幕，也能安心轉換。',
+  },
+  {
+    question: '支援哪些字幕格式？',
+    answer:
+      '本頁的轉換區接受 .srt 字幕檔（也支援 .txt 純文字）。剪映匯出字幕時，如果需要保留時間碼就選 SRT；只要純文字則可選 TXT，兩種都能直接拖進來轉換。',
+  },
+  {
+    question: '轉出來的字幕可以再匯回剪映嗎？',
+    answer:
+      '可以。轉換後下載的還是標準 .srt 檔，格式與時間軸都保持不變，直接在剪映用「導入字幕 / 本地字幕」把轉好的 SRT 重新匯入即可，字幕就會顯示為繁體中文。',
+  },
+  {
+    question: '剪映匯出 SRT 需要付費嗎？',
+    answer:
+      '看版本而定。較新版的剪映專業版在「導出」頁面內建了「字幕導出」選項，可直接輸出 SRT；部分版本或行動版的字幕匯出可能需要會員（VIP）或改用其他方式。無論你用哪種方式取得 .srt，拿到檔案後在本頁的轉換都是完全免費的。',
+  },
+];
+
+export default async function JianyingLandingPage() {
+  const user = await getAuthUser();
+  const profile = user ? await getProfile(user.id) : null;
+
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: JIANYING_FAQ.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: { '@type': 'Answer', text: item.answer },
+    })),
+  };
+
+  return (
+    <>
+      <Header user={user} profile={profile} />
+
+      <main className="flex-1 max-w-5xl mx-auto w-full px-6 py-12 flex flex-col gap-12">
+        <section className="space-y-6">
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-800 leading-snug">
+            剪映字幕簡轉繁：CapCut 字幕簡體轉台灣繁體（SRT 一鍵轉換）
+          </h1>
+          <p className="text-lg text-gray-600 max-w-4xl">
+            剪映（CapCut）用 AI 自動辨識出來的字幕，預設都是簡體中文。把在剪映匯出的
+            .srt 字幕檔拖進下方轉換區，txtconv 立刻在你的瀏覽器內轉成台灣用語的繁體中文
+            —— 時間軸與序號完全不動、檔案不上傳伺服器，轉完的 SRT 還能直接重新匯回剪映。
+          </p>
+        </section>
+
+        <FileUpload licenseType={profile?.license_type ?? 'free'} />
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold text-gray-800">
+            剪映字幕轉繁體：三步驟完成
+          </h2>
+          <ol className="list-decimal pl-6 space-y-2 text-gray-600">
+            <li>
+              在剪映（CapCut）用 AI 辨識字幕後，開啟「導出」頁面，勾選「字幕導出」，
+              選擇 <span className="font-medium text-gray-800">SRT</span>（保留時間碼）匯出字幕檔。
+            </li>
+            <li>把匯出的 .srt 檔拖曳（或點選）上傳到本頁的轉換區，會自動開始轉換。</li>
+            <li>點下載取得繁體字幕，再在剪映用「導入字幕」把轉好的 SRT 重新匯入即可。</li>
+          </ol>
+          <p className="text-sm text-gray-500">
+            提醒：剪映的字幕匯出功能與是否免費會因版本而異，部分版本可能需要會員（VIP）；
+            但只要你取得 .srt 檔，在本頁的轉換一律免費、且在瀏覽器內完成，不會上傳你的檔案。
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold text-gray-800">為什麼用 txtconv 轉剪映字幕</h2>
+          <ul className="list-disc pl-6 space-y-2 text-gray-600">
+            <li>
+              <span className="font-medium text-gray-800">時間軸不跑掉：</span>
+              只轉文字，SRT 的序號與時間碼（例如 00:00:01,000 --&gt; 00:00:03,500）原樣保留。
+            </li>
+            <li>
+              <span className="font-medium text-gray-800">台灣用語詞庫：</span>
+              使用 OpenCC 台灣正體詞庫，把「软件、视频、信息」轉成「軟體、影片、資訊」，字幕更自然。
+            </li>
+            <li>
+              <span className="font-medium text-gray-800">免上傳、更隱私：</span>
+              轉換在瀏覽器內完成，字幕檔不會離開你的電腦，也不會被存到任何伺服器。
+            </li>
+            <li>
+              <span className="font-medium text-gray-800">批次處理整季影片：</span>
+              一次拖入多個 .srt 檔，會依序自動轉換，適合系列影片或整季影集的字幕。
+            </li>
+          </ul>
+          <p className="text-sm text-gray-500">
+            我們也在研究直接讀取剪映專案檔（草稿）的字幕、免匯出 SRT 的做法；目前尚未支援，
+            現階段請先在剪映匯出 .srt 再上傳轉換。
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <p className="text-gray-600">
+            要轉換的不是字幕？也可以看{' '}
+            <a href="/srt" className="text-primary hover:underline">
+              SRT 字幕簡轉繁
+            </a>
+            、
+            <a href="/novel" className="text-primary hover:underline">
+              小說 TXT 簡轉繁
+            </a>
+            、
+            <a href="/epub" className="text-primary hover:underline">
+              EPUB 電子書簡轉繁
+            </a>
+            ，或回到
+            <Link href="/" className="text-primary hover:underline">
+              首頁
+            </Link>
+            查看完整功能與方案。
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold text-gray-800">剪映字幕轉繁體常見問題</h2>
+          <div className="space-y-4">
+            {JIANYING_FAQ.map((item) => (
+              <details
+                key={item.question}
+                className="group bg-white rounded-2xl shadow-sm border border-gray-100 px-6 py-4"
+              >
+                <summary className="cursor-pointer list-none flex items-center justify-between gap-4 font-medium text-gray-800">
+                  <h3 className="text-base font-medium">{item.question}</h3>
+                  <span className="material-symbols-outlined text-gray-400 transition-transform group-open:rotate-180">
+                    expand_more
+                  </span>
+                </summary>
+                <p className="mt-3 text-sm leading-relaxed text-gray-600">{item.answer}</p>
+              </details>
+            ))}
+          </div>
+        </section>
+
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        />
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,6 +71,10 @@ export default async function Home() {
               <a href="/srt" className="hover:text-primary underline underline-offset-2">
                 .srt 電影字幕檔案
               </a>
+              {' ／ '}
+              <a href="/jianying" className="hover:text-primary underline underline-offset-2">
+                剪映字幕簡轉繁
+              </a>
             </p>
             <p>
               <a href="/csv" className="hover:text-primary underline underline-offset-2">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -25,6 +25,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     },
     {
+      url: `${base}/jianying`,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
       url: `${base}/novel`,
       changeFrequency: 'monthly',
       priority: 0.8,

--- a/e2e/jianying.spec.ts
+++ b/e2e/jianying.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * End-to-end checks for the 剪映/CapCut subtitle workflow: a small Simplified
+ * .srt dropped on the /jianying landing page converts in-browser and produces
+ * a .srt download whose text was converted Simplified->Traditional while the
+ * SRT timing lines are preserved; and the /jianying page renders with its H1
+ * and FAQPage JSON-LD marker.
+ */
+import { test, expect } from '@playwright/test';
+
+/** Minimal two-cue Simplified SRT with 剪映-style vocabulary to convert. */
+const SIMPLIFIED_SRT = `1
+00:00:01,000 --> 00:00:03,500
+这个软件的视频信息
+
+2
+00:00:03,500 --> 00:00:06,000
+网络世界的软件测试
+`;
+
+test('simplified .srt dropped on /jianying converts and downloads as .srt', async ({ page }) => {
+  await page.goto('/jianying');
+
+  const downloadPromise = page.waitForEvent('download');
+
+  await page.setInputFiles('input[type="file"]', {
+    name: 'jianying-subtitles.srt',
+    mimeType: 'application/x-subrip',
+    buffer: Buffer.from(SIMPLIFIED_SRT, 'utf-8'),
+  });
+
+  await expect(page.getByText('Finished')).toBeVisible({ timeout: 30000 });
+
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/\.srt$/);
+
+  const stream = await download.createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(chunk as Buffer);
+  const text = Buffer.concat(chunks).toString('utf-8');
+
+  // Text converted to Traditional Chinese with Taiwan vocabulary.
+  expect(text).toContain('軟體');
+  expect(text).toContain('影片');
+  expect(text).not.toContain('软件');
+  // SRT timing lines are preserved untouched.
+  expect(text).toContain('00:00:01,000 --> 00:00:03,500');
+});
+
+test('/jianying landing page renders with H1 and FAQ JSON-LD', async ({ page }) => {
+  const response = await page.goto('/jianying');
+  expect(response?.status()).toBe(200);
+
+  await expect(
+    page.getByRole('heading', { level: 1, name: /剪映字幕簡轉繁/ })
+  ).toBeVisible();
+
+  // FAQPage structured data must be present for rich-result eligibility.
+  const jsonLd = await page
+    .locator('script[type="application/ld+json"]')
+    .innerText();
+  expect(jsonLd).toContain('FAQPage');
+
+  // Converter is embedded on the landing page too.
+  await expect(page.locator('input[type="file"]')).toBeAttached();
+});

--- a/e2e/purchase-flow.spec.ts
+++ b/e2e/purchase-flow.spec.ts
@@ -36,7 +36,7 @@ test('homepage Lifetime card shows $30 and links to the Gumroad product', async 
 });
 
 // Landing pages that embed the converter: must load and show the file input.
-for (const path of ['/srt', '/novel', '/csv']) {
+for (const path of ['/srt', '/jianying', '/novel', '/csv']) {
   test(`landing page ${path} responds 200 with the converter present`, async ({ page }) => {
     const response = await page.goto(path);
     expect(response?.status()).toBe(200);


### PR DESCRIPTION
## What & why

3 of 7 surveyed Pro buyers are subtitle/剪映 users, and there is large proven search demand for 「剪映 字幕 轉繁體」/「CapCut 字幕簡轉繁」, but txtconv had **no landing page targeting 剪映 by name** — only the generic /srt page. This new page captures that query family and funnels those users into the existing in-browser SRT converter.

剪映 (CapCut Chinese version) auto-generates **Simplified** subtitles via speech recognition; Taiwanese creators want Traditional. The page documents the honest workflow: export .srt from 剪映 (noting SRT export may require VIP on some versions), then convert here — free, in-browser, no upload — and re-import the converted SRT back into 剪映.

## Changes

- **`app/jianying/page.tsx`** (new): canonical `/jianying`, title 「剪映字幕簡轉繁｜CapCut 字幕簡體轉繁體（SRT 一鍵轉換）」, keywords (剪映字幕繁體, CapCut 簡轉繁, 剪映 SRT 繁體, 剪映字幕轉台灣繁體), H1 + persona intro, embedded `FileUpload` converter, 3-step how-to, honest VIP/no-upload notes, a vague-and-truthful roadmap line about reading 剪映 專案檔 directly (no date, no claim we parse it today), cross-links to /srt /novel /epub + home, and FAQ + FAQPage JSON-LD (Simplified subtitle handling / no server upload / supported formats .srt / re-import into 剪映 / SRT export cost).
- **`app/sitemap.ts`**: added `/jianying`.
- **`app/page.tsx`**: linked 剪映字幕簡轉繁 next to the `.srt` row (same place /srt /novel /epub /csv are linked).
- **`e2e/jianying.spec.ts`** (new): drops a Simplified `.srt` on /jianying → asserts conversion (软件→軟體, 视频→影片) with SRT timing lines preserved and `.srt` download; asserts /jianying 200 + H1 + FAQPage JSON-LD + embedded converter.
- **`e2e/purchase-flow.spec.ts`**: extended the landing-page 200/converter smoke loop to include `/jianying`.

## Verification

- `npx jest --ci`: **150/150** (13 suites) green.
- `npm run lint`: **0 errors** (2 pre-existing font warnings).
- `npm run build`: green, `/jianying` route present.
- Playwright: **full suite 13/13** green, incl. the new .srt-drop conversion + FAQPage assertions on /jianying.

Prod verification (curl new route + sitemap + homepage link) to follow after merge.