### PR TITLE
feat: upgrade dialog at the file-rejection moment (fixes the dead #pricing anchor on landing pages)

### DIFF
--- a/__tests__/components/FileUpload.test.tsx
+++ b/__tests__/components/FileUpload.test.tsx
@@ -31,6 +31,13 @@ document.createElement = jest.fn((tagName) => {
   return element;
 });
 
+/**
+ * Payment page the upgrade dialog links to. Computed exactly like the
+ * component does, so the assertion holds both locally (where .env supplies
+ * the real product URL) and in continuous integration (where it does not).
+ */
+const EXPECTED_GUMROAD_URL = process.env.NEXT_PUBLIC_GUMROAD_URL || 'https://gumroad.com';
+
 describe('FileUpload Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -39,6 +46,10 @@ describe('FileUpload Component', () => {
     (clientConverter.convertFile as jest.Mock).mockClear();
     // Reset the GTM dataLayer so each test asserts only its own events
     window.dataLayer = [];
+    // The upgrade dialog opens by itself only once per browser session and
+    // records that in sessionStorage, which jsdom keeps across tests in a
+    // file. Clearing it gives every test a fresh session.
+    window.sessionStorage.clear();
   });
 
   it('should render upload dropzone with original text', () => {
@@ -213,7 +224,7 @@ describe('FileUpload Component', () => {
     });
   });
 
-  it('should reject files over the free 5MB limit with an upgrade link', async () => {
+  it('should reject files over the free 5MB limit with an upgrade button', async () => {
     const user = userEvent.setup();
 
     render(<FileUpload licenseType="free" />);
@@ -227,11 +238,102 @@ describe('FileUpload Component', () => {
     }
 
     await waitFor(() => {
-      expect(screen.getByText(/超過免費版 5MB 上限/)).toBeInTheDocument();
+      expect(screen.getByText(/檔案 10.00MB 超過免費版 5MB 上限/)).toBeInTheDocument();
     });
-    expect(screen.getByRole('link', { name: /升級 Pro/ })).toHaveAttribute('href', '#pricing');
+    // The row offers a button (not an anchor to a homepage-only "#pricing"
+    // fragment, which did nothing on the landing pages)
+    expect(
+      screen.getByRole('button', { name: /升級 Pro 可轉換 100MB/ })
+    ).toBeInTheDocument();
     // Rejected file must never start converting
     expect(clientConverter.convertFile).not.toHaveBeenCalled();
+  });
+
+  /** Uploads a file whose size exceeds the free tier's 5MB limit. */
+  async function dropOversizedFile(
+    user: ReturnType<typeof userEvent.setup>,
+    name = 'novel.txt',
+    sizeBytes = 9 * 1024 * 1024
+  ) {
+    const file = new File(['x'], name, { type: 'text/plain' });
+    Object.defineProperty(file, 'size', { value: sizeBytes });
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(input, file);
+  }
+
+  it('should open the upgrade dialog when an oversized file is dropped', async () => {
+    const user = userEvent.setup();
+
+    render(<FileUpload licenseType="free" />);
+    await dropOversizedFile(user);
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(
+      screen.getByRole('heading', { name: '檔案超過免費版 5MB 上限' })
+    ).toBeInTheDocument();
+    // Body copy names the rejected file and its size
+    expect(screen.getByText(/「novel.txt」大小為 9.00MB/)).toBeInTheDocument();
+
+    // The buy button is a real link to the configured payment page
+    expect(
+      screen.getByRole('link', { name: /升級 Pro 終身版 US\$30/ })
+    ).toHaveAttribute('href', EXPECTED_GUMROAD_URL);
+  });
+
+  it('should close the upgrade dialog when dismissed', async () => {
+    const user = userEvent.setup();
+
+    render(<FileUpload licenseType="free" />);
+    await dropOversizedFile(user);
+
+    await screen.findByRole('dialog');
+    await user.click(screen.getByRole('button', { name: '稍後再說' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should not reopen the upgrade dialog automatically later in the same session', async () => {
+    const user = userEvent.setup();
+
+    render(<FileUpload licenseType="free" />);
+    await dropOversizedFile(user, 'first.txt');
+
+    await screen.findByRole('dialog');
+    await user.click(screen.getByRole('button', { name: '稍後再說' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    // A second oversized file is still rejected, but must not interrupt again
+    await dropOversizedFile(user, 'second.txt');
+
+    await waitFor(() => {
+      expect(screen.getByText('second.txt')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should reopen the upgrade dialog from the rejected row button', async () => {
+    const user = userEvent.setup();
+
+    render(<FileUpload licenseType="free" />);
+    await dropOversizedFile(user);
+
+    await screen.findByRole('dialog');
+    await user.click(screen.getByRole('button', { name: '稍後再說' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    // The once-per-session cap applies to automatic opening only; an explicit
+    // click must always bring the offer back
+    await user.click(screen.getByRole('button', { name: /升級 Pro 可轉換 100MB/ }));
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
   });
 
   it('should push a file_rejected dataLayer event on an oversized drop', async () => {
@@ -248,7 +350,7 @@ describe('FileUpload Component', () => {
     }
 
     await waitFor(() => {
-      expect(screen.getByText(/超過免費版 5MB 上限/)).toBeInTheDocument();
+      expect(screen.getByText(/檔案 9.00MB 超過免費版 5MB 上限/)).toBeInTheDocument();
     });
 
     const rejectedEvents = window.dataLayer.filter((e) => e.event === 'file_rejected');

--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -13,10 +13,58 @@ import {
   trackFileConversionCompleted,
   trackFileConversionFailed,
   trackFileRejected,
-  trackUpgradeCtaClicked,
 } from '@/lib/analytics';
+import PaywallDialog from '@/components/PaywallDialog';
 import { createClient } from '@/lib/supabase/client';
 import type { LicenseType } from '@/types/user';
+
+/**
+ * Marker stored in sessionStorage once the upgrade dialog has opened by
+ * itself during this browsing session. It caps the automatic interruption at
+ * one per session; explicitly clicking the upgrade button in a rejected
+ * file's row always reopens the dialog regardless of this marker.
+ */
+const PAYWALL_DIALOG_SHOWN_KEY = 'paywall_dialog_shown';
+
+/**
+ * Payment page the upgrade dialog sends buyers to. Read from the environment
+ * the same way the homepage pricing section does, with a fallback so the
+ * button is never a dead link in an environment that forgot the variable.
+ */
+const GUMROAD_URL = process.env.NEXT_PUBLIC_GUMROAD_URL || 'https://gumroad.com';
+
+/**
+ * Formats a byte count as megabytes with two decimals, matching the wording
+ * of the size-limit rejection message the validator produces.
+ */
+function formatSizeMB(bytes: number): string {
+  return (bytes / 1024 / 1024).toFixed(2);
+}
+
+/**
+ * Reads the "already interrupted this session" marker. Access to
+ * sessionStorage is guarded because browsers in some privacy modes throw on
+ * any access to it; if we cannot read the marker we treat the session as
+ * fresh, which at worst shows the dialog once more than intended.
+ */
+function paywallDialogAlreadyShown(): boolean {
+  try {
+    return window.sessionStorage.getItem(PAYWALL_DIALOG_SHOWN_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/** Records the marker; silently ignored when sessionStorage is unavailable. */
+function markPaywallDialogShown(): void {
+  try {
+    window.sessionStorage.setItem(PAYWALL_DIALOG_SHOWN_KEY, '1');
+  } catch {
+    // Storage is unavailable (private browsing, blocked cookies). The dialog
+    // simply loses its once-per-session cap, which is preferable to crashing
+    // the drop handler.
+  }
+}
 
 export interface UploadFile {
   id: string;
@@ -111,10 +159,12 @@ function FileRow({
   store,
   onDownload,
   onRetry,
+  onUpgrade,
 }: {
   store: UploadFile;
   onDownload: () => void;
   onRetry: () => void;
+  onUpgrade: () => void;
 }) {
   // Determine state
   const isUploading = store.isUploading === true;
@@ -180,13 +230,19 @@ function FileRow({
             <span className="material-symbols-outlined text-[14px]">error</span>
             <span>{store.errMessage || statusText}</span>
             {store.upgradeAvailable && (
-              <a
-                href="#pricing"
-                onClick={() => trackUpgradeCtaClicked('file_size_limit')}
+              // A button, not a link to "#pricing": that anchor only exists on
+              // the homepage, so on the landing pages that embed this
+              // converter the old link silently did nothing. Opening the
+              // upgrade dialog works identically on every page. No analytics
+              // event fires here — the dialog's own buttons carry the funnel
+              // events, so counting this click too would double-count.
+              <button
+                type="button"
+                onClick={onUpgrade}
                 className="text-primary hover:text-primary-hover font-bold underline underline-offset-2"
               >
                 升級 Pro 可轉換 100MB →
-              </a>
+              </button>
             )}
           </div>
         ) : (
@@ -235,6 +291,21 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
   const [downloadQueue, setDownloadQueue] = useState<Array<{ blob: Blob; fileName: string }>>([]);
   const isProcessingQueue = useRef(false);
   const [userId, setUserId] = useState<string | undefined>(undefined);
+  // Upgrade dialog shown when a file is rejected for exceeding the free
+  // tier's size limit. The name and size are kept separately from the file
+  // list so the dialog keeps rendering its copy while it closes.
+  const [paywallOpen, setPaywallOpen] = useState(false);
+  const [paywallFile, setPaywallFile] = useState<{ name: string; sizeMB: string }>({
+    name: '',
+    sizeMB: '0.00',
+  });
+
+  const openPaywallDialog = useCallback((name: string, sizeBytes: number) => {
+    setPaywallFile({ name, sizeMB: formatSizeMB(sizeBytes) });
+    setPaywallOpen(true);
+  }, []);
+
+  const closePaywallDialog = useCallback(() => setPaywallOpen(false), []);
 
   // Get user ID on mount
   useEffect(() => {
@@ -408,6 +479,17 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
 
     setFiles((prev) => [...prev, ...newFiles]);
 
+    // Present the upgrade offer at the moment the size limit is hit, rather
+    // than leaving it to a small link the user has to notice. Only the first
+    // such file in a drop matters, and only the first time in a session — a
+    // dialog on every subsequent drop would be nagging, and the rejected
+    // row keeps its own button for anyone who wants it back.
+    const firstUpgradeable = newFiles.find((f) => f.upgradeAvailable === true);
+    if (firstUpgradeable && !paywallDialogAlreadyShown()) {
+      markPaywallDialogShown();
+      openPaywallDialog(firstUpgradeable.file.name, firstUpgradeable.size);
+    }
+
     // Auto-convert only valid files (client-side, no upload needed)
     newFiles.forEach((uploadFile, index) => {
       if (!uploadFile.errMessage) {
@@ -416,7 +498,7 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
         }, index * 100); // Stagger by 100ms
       }
     });
-  }, [convertFile, licenseType]);
+  }, [convertFile, licenseType, openPaywallDialog]);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
@@ -492,10 +574,19 @@ export default function FileUpload({ licenseType = 'free' }: { licenseType?: Lic
               store={fileHandler}
               onDownload={() => downloadFile(fileHandler.id)}
               onRetry={() => retryFile(fileHandler.id)}
+              onUpgrade={() => openPaywallDialog(fileHandler.file.name, fileHandler.size)}
             />
           ))}
         </section>
       )}
+
+      <PaywallDialog
+        open={paywallOpen}
+        onClose={closePaywallDialog}
+        fileName={paywallFile.name}
+        fileSizeMB={paywallFile.sizeMB}
+        gumroadUrl={GUMROAD_URL}
+      />
     </div>
   );
 }

--- a/components/PaywallDialog.tsx
+++ b/components/PaywallDialog.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Link from 'next/link';
+import { trackBeginCheckout, trackUpgradeCtaClicked } from '@/lib/analytics';
+
+export interface PaywallDialogProps {
+  /** Whether the dialog is currently shown. */
+  open: boolean;
+  /** Called when the user dismisses the dialog (Escape, backdrop, ✕, 稍後再說). */
+  onClose: () => void;
+  /** Name of the file that was rejected, shown verbatim in the body copy. */
+  fileName: string;
+  /** File size in megabytes, already formatted to two decimals (e.g. "8.42"). */
+  fileSizeMB: string;
+  /** Destination of the buy button; the configured Gumroad product page. */
+  gumroadUrl: string;
+}
+
+/**
+ * Upgrade prompt shown the moment a file is rejected for exceeding the free
+ * tier's 5MB limit.
+ *
+ * Why it exists: previously a rejected file only produced a small inline
+ * "upgrade" link inside the error row. Measured behaviour showed almost
+ * nobody followed it, and on the landing pages that embed the converter the
+ * link pointed at a "#pricing" anchor that does not exist outside the
+ * homepage, so it did nothing at all. Presenting the offer as a dialog at
+ * the exact moment the limit is hit removes both problems: the offer is
+ * impossible to miss, and the buy button leaves for the payment page
+ * directly instead of relying on same-page navigation.
+ *
+ * Trade-off: a dialog interrupts the user, which is intrusive if it appears
+ * repeatedly. The caller therefore auto-opens it at most once per browser
+ * session and otherwise only on an explicit click, so a user who declines
+ * the offer is never interrupted again during that visit.
+ */
+export default function PaywallDialog({
+  open,
+  onClose,
+  fileName,
+  fileSizeMB,
+  gumroadUrl,
+}: PaywallDialogProps) {
+  const primaryButtonRef = useRef<HTMLAnchorElement>(null);
+
+  // Move keyboard focus onto the buy button as soon as the dialog appears so
+  // keyboard and screen-reader users land inside the dialog rather than
+  // staying on the page behind it.
+  useEffect(() => {
+    if (open) {
+      primaryButtonRef.current?.focus();
+    }
+  }, [open]);
+
+  // Escape closes the dialog, which is the behaviour every user expects from
+  // a modal. The listener lives on the document rather than on the dialog
+  // element so it works even if focus has moved outside the dialog.
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/50 p-0 sm:p-4"
+      // Clicking the dimmed area outside the panel dismisses the dialog. The
+      // target check keeps clicks that started inside the panel from bubbling
+      // up and closing it by accident.
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="paywall-dialog-headline"
+        // On narrow screens the panel is a full-width sheet anchored to the
+        // bottom of the viewport; from the small breakpoint upwards it becomes
+        // a centred card. Both keep the panel within the viewport width so the
+        // page never scrolls sideways.
+        className="relative w-full sm:max-w-md bg-[#fffdf5] border border-amber-100 rounded-t-2xl sm:rounded-2xl shadow-lg p-6 sm:p-8 max-h-full overflow-y-auto"
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="關閉"
+          className="absolute top-3 right-3 w-9 h-9 flex items-center justify-center rounded-full text-gray-400 hover:text-gray-600 hover:bg-black/5 transition-colors"
+        >
+          <span className="material-symbols-outlined text-[20px]">close</span>
+        </button>
+
+        <h2
+          id="paywall-dialog-headline"
+          className="text-xl sm:text-2xl font-bold text-gray-900 pr-10 mb-3"
+        >
+          檔案超過免費版 5MB 上限
+        </h2>
+
+        <p className="text-sm text-gray-600 mb-6 break-words">
+          「{fileName}」大小為 {fileSizeMB}MB。升級 Pro 終身版即可轉換最大 100MB 的檔案。
+        </p>
+
+        <ul className="text-left w-full space-y-3 mb-8 text-gray-600 text-sm">
+          <li className="flex items-start gap-2">
+            <span className="text-gray-900 mt-0.5">•</span>
+            單檔最大 100MB，批次轉換不受限
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-gray-900 mt-0.5">•</span>
+            自訂字典 10,000 組，固定人名與專有名詞譯法
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-gray-900 mt-0.5">•</span>
+            一次付費 US$30，永久使用，包含所有未來新功能
+          </li>
+        </ul>
+
+        <a
+          ref={primaryButtonRef}
+          href={gumroadUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => trackBeginCheckout(30, 'lifetime')}
+          className="w-full py-3 px-4 bg-primary hover:bg-primary-hover text-white font-bold rounded-lg transition-colors flex items-center justify-center gap-2"
+        >
+          升級 Pro 終身版 US$30 →
+        </a>
+
+        <div className="mt-4 flex flex-col items-center gap-3">
+          {/*
+            Absolute path, not a bare "#pricing" fragment: the converter is
+            embedded on several landing pages that have no pricing section of
+            their own, where a fragment-only link would do nothing.
+          */}
+          <Link
+            href="/#pricing"
+            onClick={() => trackUpgradeCtaClicked('file_size_limit')}
+            className="text-sm text-primary hover:text-primary-hover font-medium underline underline-offset-2"
+          >
+            查看完整方案比較
+          </Link>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            稍後再說
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/e2e/tiered-limits.spec.ts
+++ b/e2e/tiered-limits.spec.ts
@@ -1,29 +1,60 @@
 /**
- * End-to-end check for license-tier file-size limits: a guest dropping
- * a file over the free 5MB limit sees the rejection message with an
- * upgrade link pointing at the pricing section, and no conversion runs.
+ * End-to-end checks for license-tier file-size limits: a guest dropping a
+ * file over the free 5MB limit is shown the upgrade dialog, the dialog's buy
+ * button points at the configured payment page and reports the checkout step
+ * to analytics, and the same dialog is reachable from the rejected file's row
+ * on a landing page (where the previous "#pricing" anchor link did nothing
+ * because that section only exists on the homepage).
  */
-import { test, expect } from '@playwright/test';
-import path from 'path';
+import { test, expect, type Page } from '@playwright/test';
 
-const BIG_FILE = path.join(
-  '/private/tmp/claude-501/-Users-upchen-Dropbox-01-Projects-08-TxtConv/0c4cc49c-2c6c-42b3-b82a-0a34af1dcf74/scratchpad',
-  'big-novel.txt'
-);
+/**
+ * Expected payment-page URL. The dev server reads it from .env as
+ * NEXT_PUBLIC_GUMROAD_URL; the fallback keeps the assertion meaningful when
+ * the Playwright process itself was started without that variable.
+ */
+const GUMROAD_URL =
+  process.env.NEXT_PUBLIC_GUMROAD_URL ?? 'https://upchen.gumroad.com/l/txtconv-pro';
 
-test('guest uploading 9MB file sees free-limit error with upgrade CTA', async ({ page }) => {
+/**
+ * A file comfortably over the free tier's 5MB limit and under the paid
+ * 100MB one, built in memory at run time. It used to be read from a fixed
+ * path on disk, which broke the moment that file was cleaned up; generating
+ * it here means the spec has no external prerequisite.
+ */
+const OVERSIZED_FILE = {
+  name: 'big-novel.txt',
+  mimeType: 'text/plain',
+  // 19 bytes per repetition in UTF-8, so ~497k repetitions is just over 9MB.
+  buffer: Buffer.from('简体软件测试\n'.repeat(497_000)),
+};
+
+/** Reads the events pushed onto the Google Tag Manager dataLayer so far. */
+function readDataLayer(page: Page) {
+  return page.evaluate(() =>
+    (window as unknown as { dataLayer: Array<Record<string, unknown>> }).dataLayer.slice()
+  );
+}
+
+test.beforeEach(async ({ context }) => {
+  // The buy button is a real outbound link. Abort any request to the payment
+  // provider so the test never touches their servers.
+  await context.route(/gumroad\.com/, (route) => route.abort());
+});
+
+test('guest uploading a 9MB file sees the upgrade dialog with a working buy button', async ({
+  page,
+}) => {
   await page.goto('/');
 
-  await page.setInputFiles('input[type="file"]', BIG_FILE);
+  await page.setInputFiles('input[type="file"]', OVERSIZED_FILE);
 
-  await expect(page.getByText(/超過免費版 5MB 上限/)).toBeVisible();
+  // The rejected row still explains why the file was refused
+  await expect(page.getByText(/超過免費版 5MB 上限/).first()).toBeVisible();
 
   // The rejection itself must be measurable: a file_rejected event with
   // the free-limit reason reaches the GTM dataLayer.
-  const rejectedEvents = await page.evaluate(() =>
-    (window as unknown as { dataLayer: Array<Record<string, unknown>> }).dataLayer
-      .filter((e) => e.event === 'file_rejected')
-  );
+  const rejectedEvents = (await readDataLayer(page)).filter((e) => e.event === 'file_rejected');
   expect(rejectedEvents).toHaveLength(1);
   expect(rejectedEvents[0]).toMatchObject({
     reject_reason: 'size_limit_free',
@@ -31,24 +62,61 @@ test('guest uploading 9MB file sees free-limit error with upgrade CTA', async ({
     source_path: '/',
   });
 
-  const upgradeLink = page.getByRole('link', { name: /升級 Pro 可轉換 100MB/ });
-  await expect(upgradeLink).toBeVisible();
-  await expect(upgradeLink).toHaveAttribute('href', '#pricing');
+  // The upgrade dialog opens by itself at the moment of rejection
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(
+    dialog.getByRole('heading', { name: '檔案超過免費版 5MB 上限' })
+  ).toBeVisible();
 
-  // Clicking the CTA lands on the pricing section with the buy button
-  await upgradeLink.click();
-  await expect(page.locator('#pricing')).toBeInViewport();
-  const buyButton = page.getByRole('link', { name: /立即購買/ });
-  await expect(buyButton).toBeVisible();
+  // Buy button is a real link to the configured payment page, in a new tab
+  const buyLink = dialog.getByRole('link', { name: /升級 Pro 終身版 US\$30/ });
+  await expect(buyLink).toHaveAttribute('href', GUMROAD_URL);
+  await expect(buyLink).toHaveAttribute('target', '_blank');
+  await expect(buyLink).toHaveAttribute('rel', /noopener/);
 
-  // Funnel events reach the GTM dataLayer
-  await buyButton.click();
-  const events = await page.evaluate(() =>
-    (window as unknown as { dataLayer: Array<{ event: string }> }).dataLayer
-      .map((e) => e.event)
+  // The secondary link works off the homepage too, hence the absolute path
+  await expect(dialog.getByRole('link', { name: '查看完整方案比較' })).toHaveAttribute(
+    'href',
+    '/#pricing'
   );
-  expect(events).toContain('upgrade_cta_clicked');
-  expect(events).toContain('begin_checkout');
+
+  // Clicking the buy button reports exactly one checkout step at the shown price
+  await buyLink.click();
+  const checkoutEvents = (await readDataLayer(page)).filter((e) => e.event === 'begin_checkout');
+  expect(checkoutEvents).toHaveLength(1);
+  expect(checkoutEvents[0]).toMatchObject({
+    currency: 'USD',
+    value: 30,
+    item_name: 'lifetime',
+    source_path: '/',
+  });
+
+  // Dismissing closes the dialog
+  await dialog.getByRole('button', { name: '稍後再說' }).click();
+  await expect(page.getByRole('dialog')).toBeHidden();
+});
+
+test('rejected row on the /novel landing page opens the upgrade dialog', async ({ page }) => {
+  await page.goto('/novel');
+
+  await page.setInputFiles('input[type="file"]', OVERSIZED_FILE);
+
+  // Close the automatic dialog first, so the next appearance can only come
+  // from the row button
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: '稍後再說' }).click();
+  await expect(page.getByRole('dialog')).toBeHidden();
+
+  // This is the regression guard: the row control used to be a link to a
+  // "#pricing" anchor that does not exist on the landing pages, so clicking
+  // it did nothing at all. It must now reopen the dialog.
+  await page.getByRole('button', { name: /升級 Pro 可轉換 100MB/ }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: '檔案超過免費版 5MB 上限' })
+  ).toBeVisible();
 });
 
 test('converter works on the /srt landing page', async ({ page }) => {


### PR DESCRIPTION
## What this changes

The paywall moment (a file over the free tier's 5MB limit) previously produced only a small inline link in the rejected file's row, pointing at `href="#pricing"`. That anchor exists **only on the homepage**, so on the five landing pages that embed the converter (`/srt`, `/novel`, `/csv`, `/epub`, `/jianying`) the link was dead — clicking it did nothing.

- **New `components/PaywallDialog.tsx`** — accessible modal (`role="dialog"`, `aria-modal`, `aria-labelledby`, Escape closes, backdrop click closes, focus moves to the buy button on open; full-width bottom sheet on mobile, centred card from the small breakpoint up). Visual treatment reuses the Lifetime pricing card's tokens (`bg-[#fffdf5]`, `border-amber-100`, `bg-primary`). Copy in 台灣繁體中文.
- **`components/FileUpload.tsx`** — the dialog opens automatically on the first size rejection of each browser session (capped with a `sessionStorage` marker, all access wrapped in try/catch for privacy modes), and the rejected row's control becomes a `<button>` that reopens it, ignoring the session cap. **This alone fixes the dead anchor on all five landing pages with zero per-page work.**
- The dialog's own controls carry the funnel events: the buy button is a real `<a>` to `NEXT_PUBLIC_GUMROAD_URL` (`target="_blank"`, `rel="noopener noreferrer"`) firing the existing `trackBeginCheckout(30, 'lifetime')`; the secondary link goes to the absolute `/#pricing` firing the existing `trackUpgradeCtaClicked('file_size_limit')`. The row button fires nothing, so the same intent is never counted twice.
- **No changes** to `lib/file-validator.ts`, to any event name or payload, or to the Google Tag Manager container. The `file_rejected` / `begin_checkout` / `upgrade_cta_clicked` schemas are byte-identical, so no tag plumbing is at risk. No price changed anywhere.
- **Pre-existing test landmine fixed:** `e2e/tiered-limits.spec.ts` read its 9MB fixture from a fixed absolute path inside a temporary scratch directory from an old session, so the spec broke whenever that file was cleaned. The fixture is now generated in memory inside the spec.

## Success metric

`begin_checkout ÷ file_rejected` in GA4 property 367964438.
Baseline **4 / 1,103 = 0.36%** (2026-07-07 → 2026-07-30). Target **≥1.5%** over the 14 days after ship (≥10 `begin_checkout` against a baseline pace of ~2).
Guardrail: daily `file_conversion_completed` volume must not drop — the dialog only ever appears on a rejection, never on a successful conversion.

## Verification

**Unit tests — `npx jest --ci`: 154 passed, 13 suites** (was 150; +4 in `__tests__/components/FileUpload.test.tsx`).

```
Test Suites: 13 passed, 13 total
Tests:       154 passed, 154 total
```

New cases: oversized drop renders the dialog with the headline 檔案超過免費版 5MB 上限 and a buy link whose `href` equals the configured payment URL; 稍後再說 closes it; a second oversized drop in the same session does not auto-open; the rejected row's button reopens it.

**Build — `npm run build`: green.** All 20 routes emitted, `ƒ Proxy (Middleware)` present.

**Lint — `npm run lint`: 0 errors**, 2 pre-existing `no-page-custom-font` warnings in `app/layout.tsx` (expected).

**End-to-end — `npx playwright test`: 14 passed** (was 13). Port 3000 was cleared of orphaned servers first.

```
✓ 11 e2e/tiered-limits.spec.ts:45  guest uploading a 9MB file sees the upgrade dialog with a working buy button (2.5s)
✓ 12 e2e/tiered-limits.spec.ts:100 rejected row on the /novel landing page opens the upgrade dialog (2.8s)
✓ 13 e2e/tiered-limits.spec.ts:122 converter works on the /srt landing page (2.8s)
✓ 14 e2e/tiered-limits.spec.ts:135 small file converts normally for guests (2.8s)
  14 passed (16.2s)
```

The 9MB test asserts exactly one `begin_checkout` with `value: 30` reaches `window.dataLayer`; requests to the payment provider are aborted at the route level so their servers are never contacted.

**Real browser, both viewports** (`next start` build, `/novel`, real 9MB drop):

```
mobile-375   docScrollW=375  innerW=375   horizontalOverflow=false  focus="升級 Pro 終身版 US$30 →"
mobile-375   escapeCloses=true  backdropClickCloses=true
desktop-1280 docScrollW=1280 innerW=1280  horizontalOverflow=false  focus="升級 Pro 終身版 US$30 →"
desktop-1280 escapeCloses=true  backdropClickCloses=true
```

**`next start` + curl smoke — all 200:**

```
/                    200
/srt                 200
/novel               200
/csv                 200
/epub                200
/jianying            200
/dictionary-guide    200
```

The dialog headline was found in the served client chunk `/_next/static/chunks/3_3087s1cg6cv.js`.

## GA4 custom dimensions registered (one-off, outside the code)

None of the five parameters were registered before this change, so the 1,103 rejections could not be split into "over the 5MB limit" (upgrade offered) versus "unsupported file type" (no offer). Listing before: only `event_category` and `event_label` existed.

All five were created successfully via `POST https://analyticsadmin.googleapis.com/v1beta/properties/367964438/customDimensions`. Actual responses:

```json
{"name":"properties/367964438/customDimensions/15351150634","parameterName":"reject_reason","displayName":"reject_reason","scope":"EVENT"}
{"name":"properties/367964438/customDimensions/15350557020","parameterName":"source_path","displayName":"source_path","scope":"EVENT"}
{"name":"properties/367964438/customDimensions/15351138885","parameterName":"cta_source","displayName":"cta_source","scope":"EVENT"}
{"name":"properties/367964438/customDimensions/15351140975","parameterName":"upgrade_available","displayName":"upgrade_available","scope":"EVENT"}
{"name":"properties/367964438/customDimensions/15349751252","parameterName":"file_type","displayName":"file_type","scope":"EVENT"}
```

Confirmed by re-listing the property afterwards — 7 event-scope dimensions now present.

**Custom dimensions do not backfill.** Only data collected from 2026-07-30 onwards can be segmented by these parameters; the 2026-07-07 → 2026-07-30 baseline stays unsegmentable.
