### PR TITLE
feat: homepage broad-head SEO title/description rewrite (簡轉繁 CTR experiment)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,12 +4,15 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://txtconv.arpuli.com"),
+  // Homepage title/description target the broad-head queries 簡轉繁 and
+  // 簡體轉繁體: both keywords lead, the free/no-upload promise differentiates,
+  // and the brand name sits at the tail (CTR experiment, read out 2026-09-14).
   title: {
-    default: "txtconv - 簡轉繁線上工具｜字幕、小說 TXT 簡體轉繁體",
+    default: "簡轉繁線上工具｜免費簡體轉繁體，檔案不上傳、瀏覽器內完成｜txtconv",
     template: "%s | txtconv 簡轉繁工具",
   },
   description:
-    "免費線上簡轉繁工具：上傳 .txt 小說、.srt 字幕（剪映/CapCut）、.csv、.xml 檔案，一鍵將簡體中文轉換成台灣繁體中文。自動偵測 GBK/Big5 編碼、支援批次轉換與自訂字典，轉換在瀏覽器完成、速度快。",
+    "簡轉繁免費線上工具：簡體轉繁體一鍵完成，檔案不上傳、全程在瀏覽器轉換。支援 txt 小說、srt 字幕（剪映/CapCut）、epub 電子書、csv，自動偵測 GBK/Big5 編碼。",
   keywords: [
     "簡轉繁",
     "簡體轉繁體",
@@ -29,16 +32,16 @@ export const metadata: Metadata = {
     type: "website",
     url: "https://txtconv.arpuli.com",
     siteName: "txtconv",
-    title: "txtconv - 簡轉繁線上工具｜字幕、小說 TXT 簡體轉繁體",
+    title: "簡轉繁線上工具｜免費簡體轉繁體，檔案不上傳、瀏覽器內完成｜txtconv",
     description:
-      "免費線上將 .txt 小說、.srt 字幕、.csv、.xml 從簡體轉成繁體中文。自動偵測編碼、批次轉換、自訂字典。",
+      "簡轉繁免費線上工具：簡體轉繁體一鍵完成，檔案不上傳、全程在瀏覽器轉換。支援 txt 小說、srt 字幕（剪映/CapCut）、epub 電子書、csv，自動偵測 GBK/Big5 編碼。",
     locale: "zh_TW",
   },
   twitter: {
     card: "summary_large_image",
-    title: "txtconv - 簡轉繁線上工具",
+    title: "簡轉繁線上工具｜免費簡體轉繁體，檔案不上傳｜txtconv",
     description:
-      "免費線上將 .txt 小說、.srt 字幕、.csv、.xml 從簡體轉成繁體中文。自動偵測編碼、批次轉換、自訂字典。",
+      "簡轉繁免費線上工具：簡體轉繁體一鍵完成，檔案不上傳、全程在瀏覽器轉換。支援 txt 小說、srt 字幕（剪映/CapCut）、epub 電子書、csv，自動偵測 GBK/Big5 編碼。",
   },
   robots: {
     index: true,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -131,7 +131,7 @@ export default async function Home() {
               applicationCategory: 'UtilitiesApplication',
               operatingSystem: 'Web',
               description:
-                '線上簡轉繁工具：將 .txt 小說、.srt 字幕、.csv、.xml 檔案從簡體中文轉換成台灣繁體中文，自動偵測編碼並支援自訂字典。',
+                '簡轉繁線上工具：免費將 txt 小說、srt 字幕、epub 電子書、csv、xml 檔案從簡體轉繁體（台灣繁體中文），檔案不上傳、全程在瀏覽器完成，自動偵測編碼並支援自訂字典。',
               inLanguage: 'zh-TW',
               offers: [
                 { '@type': 'Offer', name: 'Free', price: '0', priceCurrency: 'USD' },


### PR DESCRIPTION
## What

Homepage-only broad-head SEO metadata rewrite (growth-loop iteration 18). The two broad queries 簡轉繁 (10,329 imp / 1.91% CTR / pos 4.3) and 簡體轉繁體 (4,385 imp / 0.87% CTR / pos 5.9) were showing a brand-first title; this flips the title to query-first with a differentiation promise.

- `app/layout.tsx` — `metadata.title.default`, `metadata.description`, openGraph + twitter mirrors.
- `app/page.tsx` — WebApplication JSON-LD `description` aligned with the new wording.
- **Untouched by design:** all five landing pages (/srt /novel /csv /epub /jianying), PaywallDialog, analytics events, GTM, pricing.

## Shipped copy

Title: `簡轉繁線上工具｜免費簡體轉繁體，檔案不上傳、瀏覽器內完成｜txtconv`
Description: `簡轉繁免費線上工具：簡體轉繁體一鍵完成，檔案不上傳、全程在瀏覽器轉換。支援 txt 小說、srt 字幕（剪映/CapCut）、epub 電子書、csv，自動偵測 GBK/Big5 編碼。`

Both broad keywords land inside the first 15 full-width characters; the free + no-upload + in-browser promise is the differentiator; brand name moved to the tail.

## Rejected title candidates

1. `簡轉繁｜免費簡體轉繁體 TXT・SRT 字幕小說轉換，檔案不上傳｜txtconv` — format tokens crowd the first 30 visible characters and dilute the broad promise; the niche queries are already owned at position ~1 by the dedicated landing pages, so the homepage title should sell the broad promise instead.
2. `簡轉繁・簡體轉繁體｜免費線上轉換，檔案不上傳｜txtconv` — most compact, but the back-to-back keyword pair reads as keyword stuffing rather than a natural sentence: worse expected CTR and a mild spam-signal risk.

## Pre-registered success metric

GSC exact-query CTR, window 8/15–9/11, read-out 2026-09-14: 簡轉繁 1.91% → ≥3.0%; 簡體轉繁體 0.87% → ≥1.5%. Guardrails: neither query's position worsens >1.0; niche-query clicks (srt 簡轉繁 / txt 簡轉繁 / 字幕簡轉繁) don't drop >20%; homepage total clicks don't drop.

## Verification

- `npx jest --ci`: 154/154 in 13 suites (one earlier run had 4 FileUpload failures under heavy machine load at 222s runtime; clean rerun green in 34s — act()-warning flake, not code).
- `npm run lint`: 0 errors (2 pre-existing font warnings).
- `npm run build`: green, all routes present.
- Playwright `npm run test:e2e`: 14/14 (two initial load flakes — jianying download timeout, tiered-limits dataLayer read — both pass deterministically on rerun).
- `next start` + curl: homepage serves the new `<title>`, meta description, og:title/og:description, twitter:title/twitter:description, and the new JSON-LD description.
- Negative path: curled all five landing pages; titles byte-identical to before —
  - /srt `SRT 字幕簡轉繁 — 剪映/CapCut 字幕一鍵轉繁體 | txtconv 簡轉繁工具`
  - /novel `小說 TXT 簡轉繁 — 簡體亂碼自動修復、轉台灣用語 | txtconv 簡轉繁工具`
  - /csv `CSV 簡轉繁 — Excel 開啟簡體 CSV 亂碼修復、轉台灣用語 | txtconv 簡轉繁工具`
  - /epub `EPUB 電子書簡轉繁 — 免上傳、瀏覽器內轉繁體中文 | txtconv 簡轉繁工具`
  - /jianying `剪映字幕簡轉繁｜CapCut 字幕簡體轉繁體（SRT 一鍵轉換） | txtconv 簡轉繁工具`
